### PR TITLE
fix: sendBatchを100件ずつに分割する

### DIFF
--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -97,6 +97,9 @@ const TICK_LIMIT = 200;
 /** 1回の投影で流すアウトボックスの上限, D1のバッチ上限とtickの時間を考えて抑える */
 const PROJECTION_LIMIT = 200;
 
+/** Cloudflare Queuesのプロデューサ側上限, 1回のsendBatchは100件まで, TICK_LIMITはこれを超えるので分割する */
+const SEND_BATCH_LIMIT = 100;
+
 /** 1 tickで落とす終端ジョブの上限, tickを有界に保つ */
 const SWEEP_LIMIT = 200;
 
@@ -377,7 +380,10 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 			}
 		}
 
-		if (messages.length > 0) await this.env.TSUMUGI_QUEUE.sendBatch(messages);
+		// 100件上限で分割して送る, concurrency>100だと1 tickの投入がこれを超える(ADR-0009)
+		for (let i = 0; i < messages.length; i += SEND_BATCH_LIMIT) {
+			await this.env.TSUMUGI_QUEUE.sendBatch(messages.slice(i, i + SEND_BATCH_LIMIT));
+		}
 
 		const projected = await this.#project();
 		const { deleted, retryAt } = this.#sweep(now);

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -168,10 +168,9 @@ describe('enqueueMany', () => {
 		await shard('SPLIT#0').enqueueMany(Array.from({ length: 150 }, () => ({ binding: 'SPLIT', payload: {} })));
 		await runDurableObjectAlarm(shard('SPLIT#0'));
 
-		// 分割前は1回で150件送りcaptureQueueがthrowする, 分割後は100件以下の複数バッチになる
+		// 分割前は1回で150件送りcaptureQueueがthrowする
+		// 100件単位で分割し, 過分割でないことも固定する
 		expect(sent).toHaveLength(150);
-		expect(batches.length).toBeGreaterThan(1);
-		expect(Math.max(...batches)).toBeLessThanOrEqual(100);
-		expect(batches.reduce((a, b) => a + b, 0)).toBe(150);
+		expect(batches).toEqual([100, 50]);
 	});
 });

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -6,12 +6,18 @@ const T0 = 2_000_000_000_000;
 
 function captureQueue() {
 	const sent: DispatchMessage[] = [];
+	const batches: number[] = [];
 	return {
 		sent,
+		batches,
 		queue: {
 			send: async (body: DispatchMessage) => void sent.push(body),
 			sendBatch: async (batch: Iterable<{ body: DispatchMessage }>) => {
-				for (const m of batch) sent.push(m.body);
+				const items = [...batch];
+				// プロデューサ側の100件上限, 超えると本番のsendBatchも失敗する
+				if (items.length > 100) throw new Error(`sendBatch上限100件を超過: ${items.length}`);
+				batches.push(items.length);
+				for (const m of items) sent.push(m.body);
 			},
 		},
 	};
@@ -152,5 +158,20 @@ describe('enqueueMany', () => {
 		expect(sent).toHaveLength(200);
 		const alarm = await runInDurableObject(shard('BOUND#0'), (_i, state) => state.storage.getAlarm());
 		expect(alarm).toBe(T0);
+	});
+
+	it('concurrencyが100を超えてもsendBatchは100件ずつに分割される', async () => {
+		const { sent, batches, queue } = captureQueue();
+		await install('SPLIT#0', T0, queue);
+		await shard('SPLIT#0').configure({ policy: { concurrency: 150, perKeyConcurrency: 150 } });
+
+		await shard('SPLIT#0').enqueueMany(Array.from({ length: 150 }, () => ({ binding: 'SPLIT', payload: {} })));
+		await runDurableObjectAlarm(shard('SPLIT#0'));
+
+		// 分割前は1回で150件送りcaptureQueueがthrowする, 分割後は100件以下の複数バッチになる
+		expect(sent).toHaveLength(150);
+		expect(batches.length).toBeGreaterThan(1);
+		expect(Math.max(...batches)).toBeLessThanOrEqual(100);
+		expect(batches.reduce((a, b) => a + b, 0)).toBe(150);
 	});
 });


### PR DESCRIPTION
Related: #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 大量のジョブをキューへ送信する際、上限に合わせて複数のバッチに分割するよう改善しました。
  * 同時実行数が100件を超える場合も、ジョブが正しく登録されるようになりました。

* **テスト**
  * 大量投入時のバッチ分割と、投入件数が正しく維持されることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->