### PR TITLE
fix: 壊れたmessage.bodyでもackする(ADR-0004)

### DIFF
--- a/packages/tsumugi/src/queue/consumer.ts
+++ b/packages/tsumugi/src/queue/consumer.ts
@@ -102,6 +102,8 @@ async function handleOne<Env extends ConsumerEnv>(
 	try {
 		// 分割代入もtryに入れる, 本文がnull等で壊れていても例外がackを飛ばさない(ADR-0004)
 		const body = message.body;
+		// jobIdが無い/文字列でない本文はここで弾く, performer実行とreportの対象にしない
+		if (typeof body?.jobId !== 'string') throw new Error('dispatchメッセージが不正: jobIdが無い');
 		jobId = body.jobId;
 		const { binding, attempt, payload, timeoutMs, claimRequired } = body;
 

--- a/packages/tsumugi/src/queue/consumer.ts
+++ b/packages/tsumugi/src/queue/consumer.ts
@@ -82,7 +82,11 @@ export async function handleBatch<Env extends ConsumerEnv>(
 	env: Env,
 	performers: PerformerRegistry<Env>,
 ): Promise<void> {
-	await Promise.allSettled(batch.messages.map((message) => handleOne(message, env, performers)));
+	const results = await Promise.allSettled(batch.messages.map((message) => handleOne(message, env, performers)));
+	// handleOneは内部で捕捉しきる想定だが, 漏れた例外を握るとackされずQueuesがリトライに乗せる(ADR-0004)
+	for (const result of results) {
+		if (result.status === 'rejected') console.error('tsumugi: handleOne rejected', result.reason);
+	}
 }
 
 async function handleOne<Env extends ConsumerEnv>(
@@ -90,11 +94,17 @@ async function handleOne<Env extends ConsumerEnv>(
 	env: Env,
 	performers: PerformerRegistry<Env>,
 ): Promise<void> {
-	const { jobId, binding, attempt, payload, timeoutMs, claimRequired } = message.body;
+	// 報告先の特定にjobIdが要るのでtryの外で持つ, 本文が壊れていれば取れないままになる
+	let jobId: string | undefined;
 	let ok = false;
 	let failure: string | undefined;
 
 	try {
+		// 分割代入もtryに入れる, 本文がnull等で壊れていても例外がackを飛ばさない(ADR-0004)
+		const body = message.body;
+		jobId = body.jobId;
+		const { binding, attempt, payload, timeoutMs, claimRequired } = body;
+
 		if (claimRequired && !(await shardStub(env, jobId).claim(jobId))) {
 			// 重複配送で他方が既に実行権を取っている,二重実行を避けるため何もせず降りる(ADR-0007)
 			message.ack();
@@ -118,10 +128,14 @@ async function handleOne<Env extends ConsumerEnv>(
 	} catch (error) {
 		// 本文をDOへ渡す, 捨てるとダッシュボードから失敗の理由が永久に分からない(ADR-0028)
 		failure = describeError(error);
-		console.error(`tsumugi: perform failed (${jobId})`, error);
+		console.error(`tsumugi: perform failed (${jobId ?? 'unknown'})`, error);
 	}
 
 	message.ack();
+
+	// jobIdが取れないのは本文が壊れている場合, 報告先が無いのでackだけで終える
+	// DO側のジョブはQUEUEDのまま残り, timeout経過後にreaperが沈黙として回収する
+	if (jobId === undefined) return;
 
 	try {
 		await shardStub(env, jobId).report(jobId, failure === undefined ? { ok } : { ok, error: failure });

--- a/packages/tsumugi/test/workers/consumer-errors.test.ts
+++ b/packages/tsumugi/test/workers/consumer-errors.test.ts
@@ -1,15 +1,23 @@
 import { env } from 'cloudflare:test';
-import { describe, expect, it, vi } from 'vitest';
-import { Performer } from '../../src/core/api.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Performer, type JobContext } from '../../src/core/api.js';
 import type { DispatchMessage } from '../../src/do/job-shard.js';
 import { handleBatch, type ConsumerEnv } from '../../src/queue/consumer.js';
 
 const consumerEnv: ConsumerEnv = env;
 
+/** 実行されたjobIdを控える, ackだけでなく実行の有無を検証するため */
+const performed: string[] = [];
 class Ok extends Performer<unknown, void, {}, ConsumerEnv> {
-	async perform(): Promise<void> {}
+	async perform(_payload: unknown, ctx: JobContext): Promise<void> {
+		performed.push(ctx.jobId);
+	}
 }
 const registry = { OK: Ok };
+
+beforeEach(() => {
+	performed.length = 0;
+});
 
 type FakeMessage = {
 	id: string;
@@ -57,28 +65,43 @@ describe('壊れたメッセージ(ADR-0004)', () => {
 		// 分割代入がtryの外にあると本文nullで例外が出てackに到達しない
 		expect(broken.ack).toHaveBeenCalledTimes(1);
 		expect(broken.retry).not.toHaveBeenCalled();
+		// 壊れた本文はperformerを実行しない, 正常なメッセージだけが1回実行される
+		expect(performed).toEqual(['OK#0:valid']);
 		// 同じバッチの正常なメッセージは巻き添えにならない
 		expect(valid.ack).toHaveBeenCalledTimes(1);
+	});
+
+	it('jobIdが無い本文はperformerを実行せずackする', async () => {
+		// bodyはオブジェクトだがjobIdが欠けている, claimRequired無しでも実行経路に入れない
+		const noId = message({ binding: 'OK', attempt: 1, payload: {}, timeoutMs: 60_000, claimRequired: false });
+
+		await expect(handleBatch(batchOf([noId]), consumerEnv, registry)).resolves.toBeUndefined();
+
+		expect(performed).toEqual([]);
+		expect(noId.ack).toHaveBeenCalledTimes(1);
+		expect(noId.retry).not.toHaveBeenCalled();
 	});
 });
 
 describe('reportの失敗(ADR-0004)', () => {
 	it('reportがthrowしてもackは行われQueuesのリトライに乗らない', async () => {
+		const report = vi.fn(async () => {
+			throw new Error('DO到達不能');
+		});
 		const failingEnv = {
 			JOB_SHARD: {
 				idFromName: (name: string) => name,
-				get: () => ({
-					claim: async () => true,
-					report: async () => {
-						throw new Error('DO到達不能');
-					},
-				}),
+				get: () => ({ claim: async () => true, report }),
 			},
 		} as unknown as ConsumerEnv;
 
 		const msg = message(validBody);
 		await expect(handleBatch(batchOf([msg]), failingEnv, registry)).resolves.toBeUndefined();
 
+		// performerは実行され, 成功をreportしようとして失敗する
+		expect(performed).toEqual(['OK#0:valid']);
+		expect(report).toHaveBeenCalledTimes(1);
+		expect(report).toHaveBeenCalledWith('OK#0:valid', { ok: true });
 		// 報告が失われてもackはする, ジョブはQUEUEDのまま残りreaperが拾う
 		expect(msg.ack).toHaveBeenCalledTimes(1);
 		expect(msg.retry).not.toHaveBeenCalled();

--- a/packages/tsumugi/test/workers/consumer-errors.test.ts
+++ b/packages/tsumugi/test/workers/consumer-errors.test.ts
@@ -1,0 +1,86 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it, vi } from 'vitest';
+import { Performer } from '../../src/core/api.js';
+import type { DispatchMessage } from '../../src/do/job-shard.js';
+import { handleBatch, type ConsumerEnv } from '../../src/queue/consumer.js';
+
+const consumerEnv: ConsumerEnv = env;
+
+class Ok extends Performer<unknown, void, {}, ConsumerEnv> {
+	async perform(): Promise<void> {}
+}
+const registry = { OK: Ok };
+
+type FakeMessage = {
+	id: string;
+	timestamp: Date;
+	body: DispatchMessage;
+	attempts: number;
+	ack: ReturnType<typeof vi.fn>;
+	retry: ReturnType<typeof vi.fn>;
+};
+
+function message(body: unknown): FakeMessage {
+	return {
+		id: '0',
+		timestamp: new Date(0),
+		body: body as DispatchMessage,
+		attempts: 1,
+		ack: vi.fn(),
+		// consumerはretryを呼ばない, 呼べばQueuesのリトライに乗る(ADR-0004)
+		retry: vi.fn(() => {
+			throw new Error('retryは呼ばれてはならない');
+		}),
+	};
+}
+
+function batchOf(messages: FakeMessage[]) {
+	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;
+}
+
+const validBody: DispatchMessage = {
+	jobId: 'OK#0:valid',
+	binding: 'OK',
+	attempt: 1,
+	payload: {},
+	timeoutMs: 60_000,
+	claimRequired: false,
+};
+
+describe('壊れたメッセージ(ADR-0004)', () => {
+	it('本文がnullでもackされ, 例外が同じバッチの他メッセージを巻き込まない', async () => {
+		const broken = message(null);
+		const valid = message(validBody);
+
+		await expect(handleBatch(batchOf([broken, valid]), consumerEnv, registry)).resolves.toBeUndefined();
+
+		// 分割代入がtryの外にあると本文nullで例外が出てackに到達しない
+		expect(broken.ack).toHaveBeenCalledTimes(1);
+		expect(broken.retry).not.toHaveBeenCalled();
+		// 同じバッチの正常なメッセージは巻き添えにならない
+		expect(valid.ack).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('reportの失敗(ADR-0004)', () => {
+	it('reportがthrowしてもackは行われQueuesのリトライに乗らない', async () => {
+		const failingEnv = {
+			JOB_SHARD: {
+				idFromName: (name: string) => name,
+				get: () => ({
+					claim: async () => true,
+					report: async () => {
+						throw new Error('DO到達不能');
+					},
+				}),
+			},
+		} as unknown as ConsumerEnv;
+
+		const msg = message(validBody);
+		await expect(handleBatch(batchOf([msg]), failingEnv, registry)).resolves.toBeUndefined();
+
+		// 報告が失われてもackはする, ジョブはQUEUEDのまま残りreaperが拾う
+		expect(msg.ack).toHaveBeenCalledTimes(1);
+		expect(msg.retry).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Related: #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 壊れたメッセージや本文が取得できないメッセージがあっても、同じバッチ内の他のメッセージ処理が継続するよう改善しました。
  * 処理に失敗したメッセージを適切に完了扱いとし、不要なリトライを防止しました。
  * ジョブ情報を取得できない場合でも、エラーが未処理のまま残らないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->