### PR TITLE
fix: 実行可能な投入候補を独立した窓で読む(#4)

### DIFF
--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -337,7 +337,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 	async #tick(): Promise<void> {
 		const now = this.clock.now();
 		this.#loadPolicy();
-		const jobs = this.repo.activeJobs(TICK_LIMIT);
+		const { jobs, readyCount } = this.repo.scheduleWindow(now, TICK_LIMIT);
 		const output = schedule({ now, jobs, policy: this.policy, bucket: this.#bucket });
 		this.#bucket = output.bucket;
 
@@ -383,7 +383,8 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		const { deleted, retryAt } = this.#sweep(now);
 
 		// 上限まで読んだなら残りがある可能性が高いので即座に自分を起こし直す
-		const hasMore = jobs.length >= TICK_LIMIT || projected >= PROJECTION_LIMIT || deleted >= SWEEP_LIMIT;
+		// 投入候補はreadyCountで見る, 実行中で窓が埋まっても投入すべき候補が無ければ起き直さない
+		const hasMore = readyCount >= TICK_LIMIT || projected >= PROJECTION_LIMIT || deleted >= SWEEP_LIMIT;
 		const candidates = [hasMore ? now : output.nextAlarmAt, retryAt].filter((v): v is number => v !== null);
 		const next = candidates.length > 0 ? Math.min(...candidates) : null;
 		if (next !== null) await this.ctx.storage.setAlarm(next);

--- a/packages/tsumugi/src/do/repo.ts
+++ b/packages/tsumugi/src/do/repo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, lt, lte, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, lt, lte, or, sql } from 'drizzle-orm';
 import { drizzle, type DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
 import { assertTransition } from '../core/transitions.js';
 import type { Backoff, DeliveryGuarantee, JobState, JobView, Retention } from '../core/types.js';
@@ -189,6 +189,46 @@ export class JobRepo {
 			.all();
 		this.reads++;
 		return rows.map((r) => toView(this.#toJobRow(r)));
+	}
+
+	/**
+	 * schedule()へ渡す窓, 役割ごとに分けて読む(ADR-0019 / ADR-0020, #4)
+	 *
+	 * 単一の作成順窓だと実行中や未到来のジョブが枠を占め, 後から入った実行可能ジョブが選考に入らない
+	 * 実行可能な候補を独立した窓で読むことで, 実行中がlimitを超えても投入候補が窓に残る
+	 * 実行可能ジョブ自体がlimitを超える滞留は解けない, 作成順の窓を跨ぐ分は次tick以降で拾う
+	 *
+	 * readyCountを返すのは有界判定のため, 満杯なら残りがある可能性が高く即座に起き直す
+	 */
+	scheduleWindow(now: number, limit: number): { jobs: JobView[]; readyCount: number } {
+		// 実行中(QUEUED/RUNNING): reaperの沈黙判定と在庫カウントに要る
+		const inFlight = this.db
+			.select()
+			.from(job)
+			.where(inArray(job.state, ['QUEUED', 'RUNNING']))
+			.orderBy(asc(job.createdAt), asc(job.id))
+			.limit(limit)
+			.all();
+		// 実行可能(SCHEDULED且つrun_after<=now): 投入候補, 実行中や未到来に窓を食われない
+		const ready = this.db
+			.select()
+			.from(job)
+			.where(and(eq(job.state, 'SCHEDULED'), lte(job.runAfter, now)))
+			.orderBy(asc(job.createdAt), asc(job.id))
+			.limit(limit)
+			.all();
+		// 未到来(run_after>now)の最も早い1件: futureRunAfterでalarmを張るため, 全件は要らない
+		const future = this.db
+			.select()
+			.from(job)
+			.where(and(eq(job.state, 'SCHEDULED'), gt(job.runAfter, now)))
+			.orderBy(asc(job.runAfter))
+			.limit(1)
+			.all();
+		this.reads += 3;
+		// 3つは状態/run_afterで互いに素なので重複しない
+		const jobs = [...inFlight, ...ready, ...future].map((r) => toView(this.#toJobRow(r)));
+		return { jobs, readyCount: ready.length };
 	}
 
 	countActive(): number {

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -154,3 +154,27 @@ describe('enqueueMany', () => {
 		expect(alarm).toBe(T0);
 	});
 });
+
+describe('投入候補の窓(ADR-0019 / ADR-0020, #4)', () => {
+	it('稼働中がTICK_LIMITを埋めても後から入った実行可能ジョブが投入される', async () => {
+		const { sent, queue } = captureQueue();
+		await install('WIN#0', T0, queue);
+		// 枠は空けたまま作成順の窓を実行中で埋める
+		await shard('WIN#0').configure({ policy: { concurrency: 400, perKeyConcurrency: 400 } });
+
+		// 200件を投入してtickでQUEUEDにする(実行中の在庫)
+		await shard('WIN#0').enqueueMany(Array.from({ length: 200 }, () => ({ binding: 'WIN', payload: {} })));
+		await runDurableObjectAlarm(shard('WIN#0'));
+		expect(sent).toHaveLength(200);
+
+		// 実行中200件より後に実行可能ジョブを入れる, 作成順では201件目に落ちる
+		sent.length = 0;
+		await install('WIN#0', T0 + 1_000, queue);
+		const late = await shard('WIN#0').enqueue({ binding: 'WIN', payload: { late: true }, priority: 10 });
+		await runDurableObjectAlarm(shard('WIN#0'));
+
+		// 作成順の単一窓だと201件目は選考へ入らず投入されない
+		expect(sent.map((m) => m.jobId)).toContain(late);
+		expect(await stateOf('WIN#0', late)).toBe('QUEUED');
+	});
+});


### PR DESCRIPTION
Related: #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ジョブのスケジューリング処理を改善し、実行可能なジョブがない場合に不要な再起動を抑制しました。
  - 実行中のジョブが多い状況でも、適切な候補を選択して処理できるようになりました。
  - 遅延設定されたジョブが、指定時刻以降に正しく投入されるようになりました。

- **テスト**
  - 大量のジョブ投入および遅延ジョブの実行動作を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->