### PR TITLE
feat: ADR-0010の型機構をenqueueに繋ぐ(#5)

### DIFF
--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -1,4 +1,4 @@
-import { bearerAuth, defineTsumugi, enqueue, remote } from 'tsumugi';
+import { bearerAuth, defineTsumugi, remote } from 'tsumugi';
 import { ui } from 'tsumugi/ui';
 import { Performer } from 'tsumugi/performer';
 
@@ -19,7 +19,8 @@ class Boom extends Performer<unknown, void, {}, Env> {
 // MAILはservice binding越しの別Worker,同一の登録簿に混在可(ADR-0026)
 const performers = { HELLO: Hello, BOOM: Boom, MAIL: remote('MAIL_SERVICE') };
 
-const tsumugi = defineTsumugi<Env>({
+// performersからbindingごとのpayload型とEnvを推論する, 明示の型引数は要らない(ADR-0010)
+const tsumugi = defineTsumugi({
 	performers,
 	// secretから引く,直書きするとリポジトリとバンドルの両方に残る
 	auth: bearerAuth((env: Env) => env.TSUMUGI_TOKEN, { cookie: 'tsumugi_token' }),
@@ -33,11 +34,12 @@ export default {
 	async fetch(request, env, ctx) {
 		const { pathname } = new URL(request.url);
 		if (pathname === '/enqueue') {
-			const id = await enqueue(env, { binding: 'HELLO', payload: { name: 'world' } });
+			// bindingからpayloadの型が決まる, 取り違えはコンパイルエラー(ADR-0010)
+			const id = await tsumugi.enqueue(env, { binding: 'HELLO', payload: { name: 'world' } });
 			return Response.json({ id });
 		}
 		if (pathname === '/enqueue-mail') {
-			const id = await enqueue(env, { binding: 'MAIL', payload: { to: 'a@example.com', subject: 'hi' } });
+			const id = await tsumugi.enqueue(env, { binding: 'MAIL', payload: { to: 'a@example.com', subject: 'hi' } });
 			return Response.json({ id });
 		}
 		return tsumugi.fetch!(request, env, ctx);

--- a/packages/tsumugi/src/core/api.ts
+++ b/packages/tsumugi/src/core/api.ts
@@ -95,3 +95,40 @@ export interface JobQueue<M extends Performers> {
 	enqueue(...args: { [K in keyof M]: EnqueueArgs<M, K> }[keyof M]): Promise<string>;
 	enqueueMany(items: readonly EnqueueItem<M>[]): Promise<string[]>;
 }
+
+/**
+ * 登録簿から`Performers`を導く(ADR-0010)
+ * ctorはインスタンス型を, `remote()`の印は同梱した相手のperformer型を取り出す
+ * これで`config.performers`1箇所からbindingごとのpayloadと必須キーが決まる
+ */
+export type PerformersOf<R extends Record<string, unknown>> = {
+	[K in keyof R]: R[K] extends RemoteRef<infer P>
+		? P
+		: R[K] extends new (env: any) => infer I
+			? I extends Performer<any, any, any, any>
+				? I
+				: never
+			: never;
+};
+
+/** 登録簿のctorが受け取るEnv, `defineTsumugi`が明示の型引数なしでEnvを推論するのに使う */
+export type EnvOf<R extends Record<string, unknown>> = {
+	[K in keyof R]: R[K] extends new (env: infer E) => any ? E : never;
+}[keyof R];
+
+/** enqueueの追加フィールド,`EnqueueOptions`に無くDOへ渡すもの */
+type ExtraInputFields = {
+	/** uniqueKeyの予約を保持する期間,経過後は同じキーでも新規ジョブになる */
+	uniqueForMs?: number;
+	/** 分割している場合の投入先の決定に使う(ADR-0011) */
+	partitionKey?: string;
+};
+
+/**
+ * オブジェクト形の型付きenqueue入力(ADR-0010)
+ * bindingで判別し, payloadと必須キーをperformerの宣言から強制する
+ * 構造としては`EnqueueInput`の部分集合なのでランタイムはそのままDOへ渡せる
+ */
+export type TypedEnqueueInput<M extends Performers, K extends keyof M = keyof M> = {
+	[Key in K]: { binding: Key; payload: PayloadOf<M[Key]> } & EnqueueOptions<ReqOf<M[Key]>> & ExtraInputFields;
+}[K];

--- a/packages/tsumugi/src/core/api.ts
+++ b/packages/tsumugi/src/core/api.ts
@@ -111,10 +111,17 @@ export type PerformersOf<R extends Record<string, unknown>> = {
 			: never;
 };
 
-/** 登録簿のctorが受け取るEnv, `defineTsumugi`が明示の型引数なしでEnvを推論するのに使う */
-export type EnvOf<R extends Record<string, unknown>> = {
-	[K in keyof R]: R[K] extends new (env: infer E) => any ? E : never;
-}[keyof R];
+/** unionをintersectionに畳む, 分配した関数引数の反変性を使う */
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+
+/**
+ * 登録簿のctorが受け取るEnv, `defineTsumugi`が明示の型引数なしでEnvを推論するのに使う(#5)
+ * 全performerは同一のWorker環境で初期化されるので, 各envのintersectionにする
+ * unionにすると1つのperformerのbindingしか満たさない環境も通ってしまう
+ */
+export type EnvOf<R extends Record<string, unknown>> = UnionToIntersection<
+	{ [K in keyof R]: R[K] extends new (env: infer E) => any ? E : never }[keyof R]
+>;
 
 /** enqueueの追加フィールド,`EnqueueOptions`に無くDOへ渡すもの */
 type ExtraInputFields = {

--- a/packages/tsumugi/src/entries/index.ts
+++ b/packages/tsumugi/src/entries/index.ts
@@ -22,7 +22,20 @@ export type { ConsumerEnv, PerformerCtor, PerformerRegistry, RemotePerformerServ
 export { createClient } from '../client/enqueue.js';
 export type { ClientEnv, JobShardStub, TsumugiClient } from '../client/enqueue.js';
 export { Performer, remote, isRemoteRef } from '../core/api.js';
-export type { RemoteJobContext, RemoteRef } from '../core/api.js';
+export type {
+	BaseOptions,
+	EnqueueItem,
+	EnqueueOptions,
+	EnvOf,
+	JobContext,
+	JobQueue,
+	Performers,
+	PerformersOf,
+	RemoteJobContext,
+	RemoteRef,
+	Requirements,
+	TypedEnqueueInput,
+} from '../core/api.js';
 export { InvalidJobIdError, formatJobId, parseJobId, shardName, shardNameOf } from '../core/ids.js';
 export { hashToShard, resolveShard } from '../core/shard.js';
 export { InvalidTransitionError, assertTransition, canTransition, isActive, isTerminal } from '../core/transitions.js';

--- a/packages/tsumugi/src/entries/types.ts
+++ b/packages/tsumugi/src/entries/types.ts
@@ -13,4 +13,15 @@ export type {
 	ScheduleOutput,
 } from '../core/types.js';
 export type { JobAddress } from '../core/ids.js';
-export type { BaseOptions, EnqueueItem, EnqueueOptions, JobContext, JobQueue, Performers, Requirements } from '../core/api.js';
+export type {
+	BaseOptions,
+	EnqueueItem,
+	EnqueueOptions,
+	EnvOf,
+	JobContext,
+	JobQueue,
+	Performers,
+	PerformersOf,
+	Requirements,
+	TypedEnqueueInput,
+} from '../core/api.js';

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -40,7 +40,7 @@ export type TsumugiConfig<Env extends ConsumerEnv> = {
  * `defineTsumugi`の戻り値(ADR-0010)
  * enqueueは`config.performers`から推論した`M`で型付けし, 必須キーの渡し忘れをコンパイルエラーにする
  */
-export type Tsumugi<Env, M extends Performers> = ExportedHandler<Env> & {
+export type Tsumugi<Env, M extends Performers = Performers> = ExportedHandler<Env> & {
 	/** envを束ねた型付きの投入口, `JobQueue<M>`を満たす */
 	jobs(env: Env): JobQueue<M>;
 	/** オブジェクト形の型付きenqueue, bindingでpayloadと必須キーが決まる */

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -3,6 +3,7 @@ import { createClient, type BindingConfig, type ClientEnv } from './client/enque
 import { DEFAULT_FAILED_RETENTION_MS } from './do/job-shard.js';
 import type { DispatchMessage, EnqueueInput, TsumugiJobShard } from './do/job-shard.js';
 import { handleBatch, type ConsumerEnv, type PerformerRegistry } from './queue/consumer.js';
+import type { EnvOf, JobQueue, Performers, PerformersOf, TypedEnqueueInput } from './core/api.js';
 import type { AuthMiddleware } from './api/auth.js';
 import { createRest, type RestEnv } from './api/rest.js';
 import { sweepReadModel, type SweepOptions } from './projection/sweep.js';
@@ -14,6 +15,7 @@ export type TsumugiConfig<Env extends ConsumerEnv> = {
 	/**
 	 * binding名とperformerの対応
 	 * ここ1箇所に書けばwranglerのservice bindingも型引数の手書きも要らない
+	 * この登録簿からenqueueのpayloadと必須キーの型が決まる(ADR-0010)
 	 */
 	performers: PerformerRegistry<Env>;
 	bindings?: Record<string, BindingConfig>;
@@ -34,10 +36,17 @@ export type TsumugiConfig<Env extends ConsumerEnv> = {
 	retention?: SweepOptions;
 };
 
-export type Tsumugi<Env extends ConsumerEnv> = ExportedHandler<Env> & {
-	enqueue(env: Env, input: EnqueueInput): Promise<string>;
-	enqueueMany(env: Env, inputs: readonly EnqueueInput[]): Promise<string[]>;
-	shardFor(env: Env, binding: string, partitionKey?: string): DurableObjectStub<TsumugiJobShard>;
+/**
+ * `defineTsumugi`の戻り値(ADR-0010)
+ * enqueueは`config.performers`から推論した`M`で型付けし, 必須キーの渡し忘れをコンパイルエラーにする
+ */
+export type Tsumugi<Env, M extends Performers> = ExportedHandler<Env> & {
+	/** envを束ねた型付きの投入口, `JobQueue<M>`を満たす */
+	jobs(env: Env): JobQueue<M>;
+	/** オブジェクト形の型付きenqueue, bindingでpayloadと必須キーが決まる */
+	enqueue(env: Env, input: TypedEnqueueInput<M>): Promise<string>;
+	enqueueMany(env: Env, inputs: readonly TypedEnqueueInput<M>[]): Promise<string[]>;
+	shardFor(env: Env, binding: keyof M & string, partitionKey?: string): DurableObjectStub<TsumugiJobShard>;
 };
 
 /** 分割していない既定構成向け, shards=1なので常に0番(ADR-0011) */
@@ -53,41 +62,65 @@ export async function enqueueMany<Env extends ConsumerEnv>(env: Env, inputs: rea
 	return createClient<Env>().enqueueMany(env, inputs);
 }
 
-export function defineTsumugi<Env extends ConsumerEnv>(config: TsumugiConfig<Env>): Tsumugi<Env> {
+/**
+ * `M`と`Env`は`config.performers`から推論する(ADR-0010)
+ * 明示の型引数は要らず, 登録簿1箇所からenqueueのpayloadと必須キーの型が決まる
+ */
+export function defineTsumugi<const R extends PerformerRegistry<any>>(
+	config: { performers: R } & Omit<TsumugiConfig<any>, 'performers'>,
+): Tsumugi<EnvOf<R>, PerformersOf<R>> {
+	type Env = ConsumerEnv & RestEnv;
 	const client = createClient<Env>(config.bindings ?? {});
+	// 公開の型はperformersから推論する, 実行時はEnvを問わないので内部でだけ緩める
+	const performers = config.performers as unknown as PerformerRegistry<Env>;
 
 	const rest = config.auth
-		? createRest<Env & RestEnv>(config.auth, {
+		? createRest<Env>(config.auth, {
 				...(config.ui ? { dashboard: config.ui } : {}),
-				bindings: Object.keys(config.performers),
-				enqueue: (env, input) => client.enqueue(env as unknown as Env, input),
+				bindings: Object.keys(performers),
+				enqueue: (env, input) => client.enqueue(env, input),
 				// 一覧のretryable判定に使う, UI側が押す前に可否を出せるようにする(ADR-0027)
 				failedRetentionMs: (binding) => config.bindings?.[binding]?.failedRetentionMs ?? DEFAULT_FAILED_RETENTION_MS,
 			})
 		: null;
 
-	return {
-		async fetch(request, env, ctx): Promise<Response> {
+	const handler = {
+		async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 			// 認証が設定されるまで何も生えない,設定漏れが「動かない」として現れる(ADR-0013)
 			if (!rest) return new Response('not found', { status: 404 });
-			return rest.fetch(request, env as Env & RestEnv, ctx);
+			return rest.fetch(request, env, ctx);
 		},
-		async queue(batch, env): Promise<void> {
-			await handleBatch(batch as MessageBatch<DispatchMessage>, env, config.performers);
+		async queue(batch: MessageBatch<DispatchMessage>, env: Env): Promise<void> {
+			await handleBatch(batch, env, performers);
 		},
-		async scheduled(_controller, env): Promise<void> {
+		async scheduled(_controller: ScheduledController, env: Env): Promise<void> {
 			// DO側の掃除はtickが行う,ここはD1の読み取りモデルだけ
-			const removed = await sweepReadModel((env as Env & RestEnv).TSUMUGI_DB, Date.now(), config.retention ?? {});
+			const removed = await sweepReadModel(env.TSUMUGI_DB, Date.now(), config.retention ?? {});
 			if (removed > 0) console.log(`tsumugi: swept ${removed} jobs from the read model`);
 		},
-		shardFor(env, binding, partitionKey) {
+		jobs(env: Env): JobQueue<PerformersOf<R>> {
+			return {
+				// positional形をDOが受けるEnqueueInputへ寄せる, 型はJobQueue<M>で縛る
+				enqueue: (binding: string, payload: unknown, options?: object) =>
+					client.enqueue(env, { binding, payload, ...options } as EnqueueInput),
+				enqueueMany: (items: readonly { binding: string; payload: unknown; options?: object }[]) =>
+					client.enqueueMany(
+						env,
+						items.map((it) => ({ binding: it.binding, payload: it.payload, ...it.options }) as EnqueueInput),
+					),
+			} as JobQueue<PerformersOf<R>>;
+		},
+		shardFor(env: Env, binding: string, partitionKey?: string): DurableObjectStub<TsumugiJobShard> {
 			return client.shardFor(env, binding, partitionKey) as DurableObjectStub<TsumugiJobShard>;
 		},
-		enqueue(env, input) {
-			return client.enqueue(env, input);
+		enqueue(env: Env, input: TypedEnqueueInput<PerformersOf<R>>): Promise<string> {
+			// TypedEnqueueInputは構造的にEnqueueInputの部分集合なのでそのまま渡せる
+			return client.enqueue(env, input as unknown as EnqueueInput);
 		},
-		enqueueMany(env, inputs) {
-			return client.enqueueMany(env, inputs);
+		enqueueMany(env: Env, inputs: readonly TypedEnqueueInput<PerformersOf<R>>[]): Promise<string[]> {
+			return client.enqueueMany(env, inputs as unknown as readonly EnqueueInput[]);
 		},
 	};
+
+	return handler as unknown as Tsumugi<EnvOf<R>, PerformersOf<R>>;
 }

--- a/packages/tsumugi/test/types/api.types.ts
+++ b/packages/tsumugi/test/types/api.types.ts
@@ -100,3 +100,24 @@ export function typeChecks() {
 	// @ts-expect-error uniqueKeyが無い
 	tsumugi.enqueueMany(env, [{ binding: 'SYNC', payload: { sku: 'X-1' } }]);
 }
+
+// 異なるbindingを要求するperformerを複数登録すると, 環境は各envのintersectionになる(#5)
+// 全performerは同一のWorker環境で初期化されるので, どちらのbindingも満たす環境しか受け付けない
+type EnvA = { A_DB: string };
+type EnvB = { B_QUEUE: string };
+class NeedsA extends Performer<{ x: number }, void, {}, EnvA> {
+	async perform(_payload: { x: number }, _ctx: JobContext) {}
+}
+class NeedsB extends Performer<{ y: number }, void, {}, EnvB> {
+	async perform(_payload: { y: number }, _ctx: JobContext) {}
+}
+
+const both = defineTsumugi({ performers: { A: NeedsA, B: NeedsB } });
+declare const fullEnv: EnvA & EnvB;
+
+export function envIsIntersection() {
+	// 両方のbindingを満たす環境は通る
+	both.jobs(fullEnv);
+	// @ts-expect-error A_DBしか無い環境はB_QUEUEを満たさないので拒否される
+	both.jobs({ A_DB: 'x' } as EnvA);
+}

--- a/packages/tsumugi/test/types/api.types.ts
+++ b/packages/tsumugi/test/types/api.types.ts
@@ -4,7 +4,8 @@
  * (実際に1つを正しいコードへ変えてTS2578が出ることを確認済み)
  */
 import { Performer } from '../../src/core/api.js';
-import type { JobContext, JobQueue } from '../../src/core/api.js';
+import type { JobContext } from '../../src/core/api.js';
+import { defineTsumugi } from '../../src/worker.js';
 
 class SendMail extends Performer<{ to: string; subject: string }> {
 	async perform(payload: { to: string; subject: string }, _ctx: JobContext) {
@@ -22,8 +23,11 @@ class SyncInventory extends Performer<{ sku: string }, void, { uniqueKey: true }
 	async perform(_payload: { sku: string }, _ctx: JobContext) {}
 }
 
-type M = { MAIL: SendMail; CHARGE: ChargeCard; SYNC: SyncInventory };
-declare const q: JobQueue<M>;
+// defineTsumugiが返す実体を検査対象にする, 実装の無い変数への型テストにしない(#5 / ADR-0010)
+// performersからMを推論するので, 明示の型引数は要らない
+const tsumugi = defineTsumugi({ performers: { MAIL: SendMail, CHARGE: ChargeCard, SYNC: SyncInventory } });
+declare const env: never;
+const q = tsumugi.jobs(env);
 
 // 実行はしない,型検査のみが目的
 export function typeChecks() {
@@ -81,4 +85,18 @@ export function typeChecks() {
 	const one: Promise<string> = q.enqueue('MAIL', { to: 'a@example.com', subject: 'hi' });
 	void many;
 	void one;
+
+	// オブジェクト形の型付きenqueue(config.performersから推論)
+	tsumugi.enqueue(env, { binding: 'MAIL', payload: { to: 'a@example.com', subject: 'hi' } });
+	// @ts-expect-error subjectが無い
+	tsumugi.enqueue(env, { binding: 'MAIL', payload: { to: 'a@example.com' } });
+	// concurrencyKey必須のperformerは渡し忘れがコンパイルエラー(ADR-0010)
+	tsumugi.enqueue(env, { binding: 'CHARGE', payload: { customerId: 'c1', amountJpy: 1200 }, concurrencyKey: 'cust:c1' });
+	// @ts-expect-error concurrencyKeyが無い
+	tsumugi.enqueue(env, { binding: 'CHARGE', payload: { customerId: 'c1', amountJpy: 1200 } });
+	// @ts-expect-error payloadの取り違え
+	tsumugi.enqueue(env, { binding: 'MAIL', payload: { customerId: 'c1', amountJpy: 1200 } });
+	tsumugi.enqueueMany(env, [{ binding: 'SYNC', payload: { sku: 'X-1' }, uniqueKey: 'sku:X-1' }]);
+	// @ts-expect-error uniqueKeyが無い
+	tsumugi.enqueueMany(env, [{ binding: 'SYNC', payload: { sku: 'X-1' } }]);
 }

--- a/packages/tsumugi/test/workers/access.test.ts
+++ b/packages/tsumugi/test/workers/access.test.ts
@@ -153,7 +153,7 @@ describe('cloudflareAccessミドルウェア', () => {
 		async perform(): Promise<void> {}
 	}
 
-	const handler = () => defineTsumugi<RestEnv>({ performers: { ACC: Noop }, auth: cloudflareAccess(options()) });
+	const handler = () => defineTsumugi({ performers: { ACC: Noop }, auth: cloudflareAccess(options()) });
 
 	const call = (headers: Record<string, string>) =>
 		handler().fetch!(

--- a/packages/tsumugi/test/workers/migration-check.test.ts
+++ b/packages/tsumugi/test/workers/migration-check.test.ts
@@ -12,7 +12,7 @@ class Noop extends Performer<unknown, void, {}, RestEnv> {
 	async perform(): Promise<void> {}
 }
 
-const app = defineTsumugi<RestEnv>({ performers: { MIG: Noop }, auth: bearerAuth(TOKEN) });
+const app = defineTsumugi({ performers: { MIG: Noop }, auth: bearerAuth(TOKEN) });
 
 const call = (path: string, database: D1Database) =>
 	app.fetch!(

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -13,8 +13,8 @@ class Noop extends Performer<unknown, void, {}, RestEnv> {
 	async perform(): Promise<void> {}
 }
 
-const withAuth = defineTsumugi<RestEnv>({ performers: { REST: Noop }, auth: bearerAuth(TOKEN) });
-const withoutAuth = defineTsumugi<RestEnv>({ performers: { REST: Noop } });
+const withAuth = defineTsumugi({ performers: { REST: Noop }, auth: bearerAuth(TOKEN) });
+const withoutAuth = defineTsumugi({ performers: { REST: Noop } });
 
 /** 認証未設定で塞がっていることを機械的に保証するため,ルートを列挙して総当たりする */
 const ROUTES: [method: string, path: string][] = [
@@ -27,7 +27,7 @@ const ROUTES: [method: string, path: string][] = [
 	['GET', '/api/unknown'],
 ];
 
-const call = (handler: typeof withAuth, method: string, path: string, headers: Record<string, string> = {}) =>
+const call = (handler: ExportedHandler<RestEnv>, method: string, path: string, headers: Record<string, string> = {}) =>
 	handler.fetch!(
 		new Request(`https://example.com${path}`, { method, headers }),
 		env as RestEnv,
@@ -84,7 +84,7 @@ describe('fail-closed認証(ADR-0013)', () => {
 });
 
 describe('secretからのトークン解決', () => {
-	const fromEnv = defineTsumugi<RestEnv>({
+	const fromEnv = defineTsumugi({
 		performers: { REST: Noop },
 		auth: bearerAuth((env: { TSUMUGI_TOKEN?: string }) => env.TSUMUGI_TOKEN),
 	});
@@ -233,7 +233,7 @@ describe('ジョブの投入', () => {
 
 describe('保持期間を過ぎたジョブの操作(ADR-0027)', () => {
 	// 一覧はD1から引くのでDOから消えても行は残る, 押す前と押した後の両方で分かる必要がある
-	const shortLived = defineTsumugi<RestEnv>({
+	const shortLived = defineTsumugi({
 		performers: { GONE: Noop },
 		auth: bearerAuth(TOKEN),
 		bindings: { GONE: { failedRetentionMs: 1 } },
@@ -250,7 +250,7 @@ describe('保持期間を過ぎたジョブの操作(ADR-0027)', () => {
 			.run();
 	}
 
-	const post = (handler: typeof withAuth, path: string) =>
+	const post = (handler: ExportedHandler<RestEnv>, path: string) =>
 		handler.fetch!(
 			new Request(`https://example.com${path}`, { method: 'POST', headers: authorized }),
 			env as RestEnv,
@@ -288,7 +288,7 @@ describe('保持期間を過ぎたジョブの操作(ADR-0027)', () => {
 	});
 
 	it('窓の内側の失敗ジョブはretryable=true', async () => {
-		const generous = defineTsumugi<RestEnv>({
+		const generous = defineTsumugi({
 			performers: { GONE: Noop },
 			auth: bearerAuth(TOKEN),
 			bindings: { GONE: { failedRetentionMs: 7 * 24 * 60 * 60 * 1000 } },

--- a/packages/tsumugi/test/workers/ui.test.ts
+++ b/packages/tsumugi/test/workers/ui.test.ts
@@ -13,7 +13,7 @@ class Noop extends Performer<unknown, void, {}, RestEnv> {
 }
 
 const handler = (options: { auth?: boolean; basePath?: string } = {}) =>
-	defineTsumugi<RestEnv>({
+	defineTsumugi({
 		performers: { UI: Noop },
 		...(options.auth === false ? {} : { auth: bearerAuth(TOKEN) }),
 		ui: ui(options.basePath === undefined ? {} : { basePath: options.basePath }),
@@ -83,7 +83,7 @@ describe('ダッシュボードの配信(ADR-0025)', () => {
 	});
 
 	it('tokenCookieを注入する', async () => {
-		const h = defineTsumugi<RestEnv>({
+		const h = defineTsumugi({
 			performers: { UI: Noop },
 			auth: bearerAuth(TOKEN),
 			ui: ui({ tokenCookie: 'tsumugi_token' }),


### PR DESCRIPTION
Related: #5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 登録済みの処理に応じて、`enqueue`／`enqueueMany` のペイロードや必須オプションを自動判定できるようになりました。
  - ジョブ取得機能と、処理名に基づく型安全なシャーディング指定を追加しました。
- **改善**
  - 環境や処理の型を明示せず、設定内容から自動推論できるようになりました。
  - 公開APIから関連する型定義を利用しやすくなりました。
- **テスト**
  - ペイロードの不一致や必須オプション不足を検出する型検査を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->