### PR TITLE
fix: 実行時のconfigure()を静的設定より優先する(#6)

### DIFF
--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -160,15 +160,23 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 	}
 
 	async configure(settings: ShardSettings): Promise<void> {
-		this.#applySettings(settings);
+		// configure()は実行時の意思, 静的設定より優先する印を付ける(#6)
+		this.#applySettings(settings, true);
 	}
 
-	/** 内容が変わっていなければ書き込まない, enqueueのたびに1回増えるのを避ける */
-	#applySettings(settings: ShardSettings): void {
+	/**
+	 * 設定を反映する, 内容が変わっていなければ書き込まない(enqueueのたびに1回増えるのを避ける)
+	 * pinnedはconfigure()由来か, enqueue同梱の静的設定か
+	 * 一度configure()されたら以降の静的設定は無視する, 実行時に絞った流量が次の投入で戻らないようにする(#6)
+	 * 静的設定へ戻すには再度configure()する
+	 */
+	#applySettings(settings: ShardSettings, pinned: boolean): void {
+		if (!pinned && this.repo.readSetting('settings_pinned') === '1') return;
 		const encoded = JSON.stringify(settings);
 		this.policy = { ...DEFAULT_POLICY, ...settings.policy };
 		this.retention = retentionOf(settings);
 		this.#policyLoaded = true;
+		if (pinned && this.repo.readSetting('settings_pinned') !== '1') this.repo.writeSetting('settings_pinned', '1');
 		if (this.repo.readSetting('settings') === encoded) return;
 		this.repo.writeSetting('settings', encoded);
 	}
@@ -186,7 +194,8 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 	async enqueueMany(inputs: readonly EnqueueInput[], settings?: ShardSettings): Promise<string[]> {
 		const now = this.clock.now();
 		this.#loadPolicy();
-		if (settings) this.#applySettings(settings);
+		// enqueue同梱は静的設定, configure()でpinされていれば無視する(#6)
+		if (settings) this.#applySettings(settings, false);
 		const ids: string[] = [];
 
 		for (const input of inputs) {

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -124,6 +124,33 @@ describe('ポリシーの永続化', () => {
 		// 増えるのはジョブのinsertとアウトボックス追記の2回だけ,ポリシーの再書き込みは起きない
 		expect(after - before).toBe(2);
 	});
+
+	it('実行時のconfigure()が次のenqueueの静的設定で上書きされない(#6)', async () => {
+		const { sent, queue } = captureQueue();
+		await install('PAUSE#0', T0, queue);
+
+		// 実行時にconcurrency=0で止める, 現状で唯一のpause手段
+		await shard('PAUSE#0').configure({ policy: { concurrency: 0 } });
+		// 静的設定を同梱したenqueue, 従来はこれがpauseを解除していた
+		await shard('PAUSE#0').enqueueMany([{ binding: 'PAUSE', payload: {} }], { policy: { concurrency: 100 } });
+		await runDurableObjectAlarm(shard('PAUSE#0'));
+
+		// pauseが保持され1件も投入されない
+		expect(sent).toHaveLength(0);
+	});
+
+	it('configure()の後は実行時のconfigure()で解除できる(#6)', async () => {
+		const { sent, queue } = captureQueue();
+		await install('PAUSE2#0', T0, queue);
+
+		await shard('PAUSE2#0').configure({ policy: { concurrency: 0 } });
+		await shard('PAUSE2#0').enqueueMany([{ binding: 'PAUSE2', payload: {} }], { policy: { concurrency: 100 } });
+		// 静的設定ではなく実行時のconfigure()なら解除できる
+		await shard('PAUSE2#0').configure({ policy: { concurrency: 100 } });
+		await runDurableObjectAlarm(shard('PAUSE2#0'));
+
+		expect(sent).toHaveLength(1);
+	});
 });
 
 describe('enqueueMany', () => {


### PR DESCRIPTION
Related: #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 実行時に設定した同時実行数（concurrency）が、ジョブ投入時の静的設定によって意図せず上書きされる問題を修正しました。
  * 実行時設定で処理を一時停止した後、同時実行数を再設定して処理を再開できるようになりました。
  * 実行時に固定した設定は、以後のジョブ投入時にも維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->