### PR TITLE
feat: performの戻り値を保存し取得できるようにする(#9)

### DIFF
--- a/packages/tsumugi/migrations/0003_add_result.sql
+++ b/packages/tsumugi/migrations/0003_add_result.sql
@@ -1,0 +1,4 @@
+-- performの戻り値(#9)
+-- 成功時にJSON文字列で入る, 上限超過や非直列化はnull
+-- 投影はジョブのスナップショットに同梱して運ぶので, 冪等性の判定はseqのまま1つで足りる
+ALTER TABLE job ADD COLUMN result TEXT;

--- a/packages/tsumugi/src/api/rest.ts
+++ b/packages/tsumugi/src/api/rest.ts
@@ -278,6 +278,8 @@ export function createRest<Env extends RestEnv>(auth: AuthMiddleware, options: R
 			updated_at: found.updatedAt,
 			dispatched_at: found.dispatchedAt,
 			payload: found.payload,
+			// performの戻り値, 成功時のみ入り未完了はnull(#9), payloadと同じくJSON文字列のまま返す
+			result: found.result,
 		};
 		// 履歴は詳細でだけ返す, 一覧に載せると1画面で数百KBになり得る(ADR-0028)
 		// `attempts`は試行回数の数値なので別名にする, 潰すと画面の n/m が壊れる

--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -7,8 +7,25 @@ import type { Backoff, Bucket, DeliveryGuarantee, Policy, Retention } from '../c
 import { systemClock, type Clock } from './clock.js';
 import { writeMetrics } from '../analytics/writer.js';
 import { project } from '../projection/projector.js';
-import { JobRepo } from './repo.js';
+import { JobRepo, RESULT_MAX_CHARS } from './repo.js';
 import type { JobRow } from './schema.js';
+
+/**
+ * performの戻り値を保存用のJSON文字列にする(#9)
+ * 戻り値なし/非直列化/上限超過はnullに落とす, 大きい結果はperformerがR2等へ書く運用
+ */
+function serializeResult(value: unknown): string | null {
+	if (value === undefined) return null;
+	let text: string | undefined;
+	try {
+		text = JSON.stringify(value);
+	} catch {
+		// 循環参照など直列化できないものは保存しない
+		return null;
+	}
+	if (text === undefined || text.length > RESULT_MAX_CHARS) return null;
+	return text;
+}
 
 /** Queuesに載せるメッセージ,ペイロードはここに同梱してconsumerがDOを引かずに済むようにする */
 export type DispatchMessage = {
@@ -228,7 +245,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 	 * 失敗ならバックオフを計算してSCHEDULEDへ戻す,試行回数を使い切っていればFAILED
 	 * リトライ方針をここが持つのでQueuesの`max_retries`に縛られない(ADR-0004)
 	 */
-	async report(jobId: string, result: { ok: boolean; error?: string }): Promise<void> {
+	async report(jobId: string, outcome: { ok: boolean; error?: string; result?: unknown }): Promise<void> {
 		const now = this.clock.now();
 		const row = this.repo.find(jobId);
 		// 報告を受け付けられる状態かをここで見る
@@ -238,21 +255,26 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		const attempts = row.attempts + 1;
 		// 1回目で成功したジョブの履歴はジョブ行から導出できるので書かない
 		// 導出できないのは失敗の理由と試行ごとの時刻だけ, 常時書くと1ジョブあたりの書き込みが1回増える
-		const worthRecording = !result.ok || attempts > 1;
+		const worthRecording = !outcome.ok || attempts > 1;
 		// 遷移でdispatched_atが消えるので開始時刻は先に確保する
 		if (worthRecording)
 			this.#recordAttempt(
 				jobId,
 				attempts,
-				result.ok ? 'COMPLETED' : 'FAILED',
+				outcome.ok ? 'COMPLETED' : 'FAILED',
 				row.dispatched_at,
 				now,
-				result.ok ? null : (result.error ?? null),
+				outcome.ok ? null : (outcome.error ?? null),
 			);
 
-		if (result.ok) {
+		if (outcome.ok) {
 			// 1回実行して成功したならattemptsは1,失敗時だけ数えると完了ジョブが0回に見える
-			this.repo.compareAndSet(jobId, ['QUEUED', 'RUNNING'], 'COMPLETED', { now, countAttempt: true });
+			// 結果は同じ遷移のsetに相乗りさせる, 別UPDATEにすると書き込みが1増える(#9)
+			this.repo.compareAndSet(jobId, ['QUEUED', 'RUNNING'], 'COMPLETED', {
+				now,
+				countAttempt: true,
+				result: serializeResult(outcome.result),
+			});
 			await this.#armAlarm(now);
 			return;
 		}

--- a/packages/tsumugi/src/do/repo.ts
+++ b/packages/tsumugi/src/do/repo.ts
@@ -11,6 +11,13 @@ import { attempt, job, outbox, setting, uniqueKey } from './tables.js';
  */
 export const ERROR_MAX_CHARS = 2_000;
 
+/**
+ * performの戻り値の保存上限(#9)
+ * 戻り値はアウトボックスのスナップショットに乗り毎回の投影で運ばれるので, 無制限だとDOとD1を圧迫する
+ * 超える結果はR2/KV/D1へ自分で書く運用にし, ここではnullに落とす
+ */
+export const RESULT_MAX_CHARS = 8_192;
+
 /** 1ジョブあたりに残す試行の数, maxAttemptsを大きくしてもスナップショットが膨らまないようにする */
 export const ATTEMPT_KEEP = 20;
 
@@ -96,6 +103,7 @@ export class JobRepo {
 				updatedAt: newJob.createdAt,
 				dispatchedAt: null,
 				payload: JSON.stringify(newJob.payload),
+				result: null,
 				runId: null,
 				nodeId: null,
 			})
@@ -226,6 +234,7 @@ export class JobRepo {
 			updated_at: r.updatedAt,
 			dispatched_at: r.dispatchedAt,
 			payload: r.payload,
+			result: r.result,
 			run_id: r.runId,
 			node_id: r.nodeId,
 		};
@@ -240,7 +249,7 @@ export class JobRepo {
 		id: string,
 		from: readonly JobState[],
 		to: JobState,
-		patch: { now: number; dispatchedAt?: number | null; attempts?: number; runAfter?: number; countAttempt?: boolean },
+		patch: { now: number; dispatchedAt?: number | null; attempts?: number; runAfter?: number; countAttempt?: boolean; result?: string | null },
 	): boolean {
 		for (const state of from) assertTransition(state, to);
 
@@ -248,6 +257,8 @@ export class JobRepo {
 		if (patch.dispatchedAt !== undefined) set.dispatchedAt = patch.dispatchedAt;
 		if (patch.attempts !== undefined) set.attempts = patch.attempts;
 		if (patch.runAfter !== undefined) set.runAfter = patch.runAfter;
+		// 成功報告と同じ遷移で結果も入れる, 書き込みを増やさないため別UPDATEにしない(#9)
+		if (patch.result !== undefined) set.result = patch.result;
 		// 現在値を読まずに加算する,成功報告の経路で読み取りを増やさないため
 		if (patch.countAttempt) set.attempts = sql`${job.attempts} + 1`;
 

--- a/packages/tsumugi/src/do/repo.ts
+++ b/packages/tsumugi/src/do/repo.ts
@@ -249,7 +249,14 @@ export class JobRepo {
 		id: string,
 		from: readonly JobState[],
 		to: JobState,
-		patch: { now: number; dispatchedAt?: number | null; attempts?: number; runAfter?: number; countAttempt?: boolean; result?: string | null },
+		patch: {
+			now: number;
+			dispatchedAt?: number | null;
+			attempts?: number;
+			runAfter?: number;
+			countAttempt?: boolean;
+			result?: string | null;
+		},
 	): boolean {
 		for (const state of from) assertTransition(state, to);
 

--- a/packages/tsumugi/src/do/schema.ts
+++ b/packages/tsumugi/src/do/schema.ts
@@ -22,6 +22,8 @@ export const SCHEMA = [
 		updated_at INTEGER NOT NULL,
 		dispatched_at INTEGER,
 		payload TEXT NOT NULL,
+		-- performの戻り値, 成功時にJSON文字列で入る(#9), 上限超過や非直列化はnull
+		result TEXT,
 		-- v2のDAG用の予約席(ADR-0015),後からスキーマを書き換えずに済むよう最初から置く
 		run_id TEXT,
 		node_id TEXT
@@ -65,6 +67,17 @@ export const SCHEMA = [
 
 export function applySchema(sql: SqlStorage): void {
 	for (const statement of SCHEMA) sql.exec(statement);
+	// CREATE TABLE IF NOT EXISTSは既存テーブルを変更しない, resultを後から足したので既存DOへ補う(#9)
+	ensureColumn(sql, 'job', 'result', 'TEXT');
+}
+
+/** 既存の表に列が無ければ足す, 冪等にするため先に有無を確かめる */
+function ensureColumn(sql: SqlStorage, table: string, column: string, type: string): void {
+	const exists = sql
+		.exec<{ name: string }>(`SELECT name FROM pragma_table_info(?)`, table)
+		.toArray()
+		.some((row) => row.name === column);
+	if (!exists) sql.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
 }
 
 /** 試行1回ぶんの記録 */
@@ -95,6 +108,7 @@ export type JobRow = {
 	updated_at: number;
 	dispatched_at: number | null;
 	payload: string;
+	result: string | null;
 	run_id: string | null;
 	node_id: string | null;
 };

--- a/packages/tsumugi/src/do/tables.ts
+++ b/packages/tsumugi/src/do/tables.ts
@@ -25,6 +25,8 @@ export const job = sqliteTable(
 		updatedAt: integer('updated_at').notNull(),
 		dispatchedAt: integer('dispatched_at'),
 		payload: text('payload').notNull(),
+		// performの戻り値, 成功時にJSON文字列で入る(#9)
+		result: text('result'),
 		// v2のDAG用の予約席(ADR-0015),後からスキーマを書き換えずに済むよう最初から置く
 		runId: text('run_id'),
 		nodeId: text('node_id'),

--- a/packages/tsumugi/src/projection/migrations.ts
+++ b/packages/tsumugi/src/projection/migrations.ts
@@ -10,7 +10,7 @@
  * このバージョンが要求するマイグレーション
  * `migrations/`の実ファイルと一致していないと検査が無意味になるので, 単体テストで突き合わせる
  */
-export const EXPECTED_MIGRATIONS = ['0001_create_job_read_model.sql', '0002_add_attempt_log.sql'] as const;
+export const EXPECTED_MIGRATIONS = ['0001_create_job_read_model.sql', '0002_add_attempt_log.sql', '0003_add_result.sql'] as const;
 
 export type MigrationStatus = { ok: true } | { ok: false; missing: string[] };
 

--- a/packages/tsumugi/src/projection/projector.ts
+++ b/packages/tsumugi/src/projection/projector.ts
@@ -33,6 +33,8 @@ function toValues(snapshot: JobSnapshot, seq: number): typeof job.$inferInsert {
 		updatedAt: snapshot.updated_at,
 		dispatchedAt: snapshot.dispatched_at,
 		payload: snapshot.payload,
+		// 古いスナップショットにはresultが無いのでnullに寄せる(#9)
+		result: snapshot.result ?? null,
 		runId: snapshot.run_id,
 		nodeId: snapshot.node_id,
 		// 履歴が無いジョブでnullを入れる, 空配列にすると「取れなかった」と区別できない

--- a/packages/tsumugi/src/projection/tables.ts
+++ b/packages/tsumugi/src/projection/tables.ts
@@ -25,6 +25,8 @@ export const job = sqliteTable(
 		updatedAt: integer('updated_at').notNull(),
 		dispatchedAt: integer('dispatched_at'),
 		payload: text('payload').notNull(),
+		// performの戻り値, DOのjob.resultをそのまま投影する(#9)
+		result: text('result'),
 		runId: text('run_id'),
 		nodeId: text('node_id'),
 		attemptsLog: text('attempts_log'),

--- a/packages/tsumugi/src/queue/consumer.ts
+++ b/packages/tsumugi/src/queue/consumer.ts
@@ -93,6 +93,7 @@ async function handleOne<Env extends ConsumerEnv>(
 	const { jobId, binding, attempt, payload, timeoutMs, claimRequired } = message.body;
 	let ok = false;
 	let failure: string | undefined;
+	let result: unknown;
 
 	try {
 		if (claimRequired && !(await shardStub(env, jobId).claim(jobId))) {
@@ -110,9 +111,10 @@ async function handleOne<Env extends ConsumerEnv>(
 			// 設定漏れの即時失敗,握り潰すと黙って失敗し続ける
 			if (typeof service?.perform !== 'function') throw new Error(`service bindingが未設定: ${entry.binding}`);
 			// signalは非対応,中断の依頼はリモートに届かない(ADR-0026)
-			await withTimeout(jobId, timeoutMs, () => Promise.resolve(service.perform(payload, base)));
+			result = await withTimeout(jobId, timeoutMs, () => Promise.resolve(service.perform(payload, base)));
 		} else {
-			await withTimeout(jobId, timeoutMs, (signal) => Promise.resolve(new entry(env).perform(payload, { ...base, signal })));
+			// performの戻り値を拾ってDOへ渡す, 保存はDO側で行う(#9)
+			result = await withTimeout(jobId, timeoutMs, (signal) => Promise.resolve(new entry(env).perform(payload, { ...base, signal })));
 		}
 		ok = true;
 	} catch (error) {
@@ -124,7 +126,9 @@ async function handleOne<Env extends ConsumerEnv>(
 	message.ack();
 
 	try {
-		await shardStub(env, jobId).report(jobId, failure === undefined ? { ok } : { ok, error: failure });
+		// exactOptionalPropertyTypesのためerror未定義は省いて渡す
+		const outcome = ok ? { ok: true, result } : failure === undefined ? { ok: false } : { ok: false, error: failure };
+		await shardStub(env, jobId).report(jobId, outcome);
 	} catch (error) {
 		// 報告が失われるとジョブはQUEUEDのまま残る, reaperが沈黙として回収する
 		console.error(`tsumugi: report failed (${jobId})`, error);

--- a/packages/tsumugi/test/workers/metrics.test.ts
+++ b/packages/tsumugi/test/workers/metrics.test.ts
@@ -22,6 +22,7 @@ const row = (over: Partial<JobRow> = {}): JobRow => ({
 	updated_at: T0 + 5_000,
 	dispatched_at: T0 + 1_000,
 	payload: '{}',
+	result: null,
 	run_id: null,
 	node_id: null,
 	...over,

--- a/packages/tsumugi/test/workers/migration-check.test.ts
+++ b/packages/tsumugi/test/workers/migration-check.test.ts
@@ -60,7 +60,7 @@ describe('マイグレーション適用漏れの検出', () => {
 
 	it('欠けていれば名前を返す', async () => {
 		const status = await checkMigrations(withLedger([{ name: '0001_create_job_read_model.sql' }]));
-		expect(status).toEqual({ ok: false, missing: ['0002_add_attempt_log.sql'] });
+		expect(status).toEqual({ ok: false, missing: ['0002_add_attempt_log.sql', '0003_add_result.sql'] });
 	});
 
 	it('台帳自体が無ければ全件未適用として扱う', async () => {

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -153,6 +153,7 @@ describe('REST API', () => {
 			'max_attempts',
 			'payload',
 			'priority',
+			'result',
 			'retryable',
 			'state',
 			'unique_key',

--- a/packages/tsumugi/test/workers/upsert-columns.test.ts
+++ b/packages/tsumugi/test/workers/upsert-columns.test.ts
@@ -36,7 +36,7 @@ describe('投影のUPSERTが更新する列', () => {
 
 	it('変わり得る列は更新する', () => {
 		const set = setClauseOf();
-		for (const column of ['"seq"', '"state"', '"attempts"', '"updated_at"', '"payload"', '"attempts_log"']) {
+		for (const column of ['"seq"', '"state"', '"attempts"', '"updated_at"', '"payload"', '"result"', '"attempts_log"']) {
 			expect(set.includes(`${column} = `), `${column}が更新対象から漏れている`).toBe(true);
 		}
 	});

--- a/packages/tsumugi/test/workers/vertical-slice.test.ts
+++ b/packages/tsumugi/test/workers/vertical-slice.test.ts
@@ -22,7 +22,14 @@ class Boom extends Performer<unknown, void, {}, ConsumerEnv> {
 	}
 }
 
-const registry = { HELLO: Hello, BOOM: Boom };
+/** 戻り値を返すperformer, resultの保存経路を見る(#9) */
+class Echo extends Performer<{ msg: string }, { echoed: string }, {}, ConsumerEnv> {
+	async perform(payload: { msg: string }): Promise<{ echoed: string }> {
+		return { echoed: payload.msg };
+	}
+}
+
+const registry = { HELLO: Hello, BOOM: Boom, ECHO: Echo };
 
 const consumerEnv: ConsumerEnv = env;
 
@@ -125,6 +132,30 @@ describe('縦串: enqueueからCOMPLETEDまで', () => {
 		expect(acked).toHaveLength(1);
 		// リトライ方針はDOが持つので,状態はFAILEDではなくSCHEDULEDに戻る
 		expect(await stateOf('BOOM', jobId)).toBe('SCHEDULED');
+	});
+
+	it('performの戻り値が保存されD1へ投影される(#9)', async () => {
+		const stub = shard('ECHO');
+		const { sent, queue } = captureQueue();
+
+		await runInDurableObject(stub, (instance) => {
+			(instance as any).clock = fixedClock(T0);
+			(instance as any).env.TSUMUGI_QUEUE = queue;
+		});
+
+		const jobId = await stub.enqueue({ binding: 'ECHO', payload: { msg: 'hi' } });
+		await runDurableObjectAlarm(stub);
+		await handleBatch(makeBatch(sent).batch, consumerEnv, registry);
+		expect(await stateOf('ECHO', jobId)).toBe('COMPLETED');
+
+		// DOのjob行に戻り値がJSON文字列で保存される
+		const row = await runInDurableObject(shard('ECHO'), (instance) => (instance as any).repo.find(jobId) as { result: string | null });
+		expect(row.result).toBe(JSON.stringify({ echoed: 'hi' }));
+
+		// 次のtickでCOMPLETEDのスナップショットがD1へ投影され戻り値も運ばれる
+		await runDurableObjectAlarm(stub);
+		const projected = await env.TSUMUGI_DB.prepare('SELECT result FROM job WHERE id = ?').bind(jobId).first<{ result: string | null }>();
+		expect(projected?.result).toBe(JSON.stringify({ echoed: 'hi' }));
 	});
 });
 


### PR DESCRIPTION
Related: #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ジョブ実行時の戻り値を保存できるようになりました。
  * ジョブ詳細APIで、実行結果を`result`として取得できます。
  * 未完了または保存できない結果は`null`として扱われます。
  * 結果はサイズ上限内でJSON形式に変換して保存されます。

* **改善**
  * 既存データベースにも結果保存用の項目を安全に追加できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->