### PR TITLE
fix: ノードの一括書き込みの上限超過とグラフの線の描画

### DIFF
--- a/packages/dashboard/src/components/RunGraph.vue
+++ b/packages/dashboard/src/components/RunGraph.vue
@@ -62,6 +62,53 @@ function setCard(id: string, element: unknown): void {
 	else cards.delete(id);
 }
 
+type Rect = { l: number; r: number; t: number; b: number };
+
+/** 迂回に使う隙間の下限, これ未満は通しても線が両側のカードに接する */
+const MIN_GAP = 8;
+
+/**
+ * 中間の列を通す高さ, カードの隙間のうち目標に近いものを選ぶ
+ * 隙間が無ければ目標のまま返す, カードの背後を通る
+ */
+function passY(column: Rect[], target: number, bottom: number): number {
+	const gaps: [number, number][] = [];
+	for (let i = 0; i + 1 < column.length; i++) gaps.push([column[i]!.b, column[i + 1]!.t]);
+	const last = column[column.length - 1];
+	if (last) gaps.push([last.b, bottom]);
+
+	let best: number | null = null;
+	for (const [from, to] of gaps) {
+		if (to - from < MIN_GAP) continue;
+		const center = (from + to) / 2;
+		if (best === null || Math.abs(center - target) < Math.abs(best - target)) best = center;
+	}
+	return best ?? target;
+}
+
+/**
+ * 1本ぶんの経路
+ * 隣の列へはそのまま曲線を引く, 列を跨ぐ場合は中間の列を隙間で横切る
+ */
+function pathFor(a: Rect, b: Rect, between: Rect[][], bottom: number): string {
+	const y1 = (a.t + a.b) / 2;
+	const y2 = (b.t + b.b) / 2;
+	let x = a.r;
+	let y = y1;
+	let d = `M${x} ${y}`;
+	for (const column of between) {
+		const left = Math.min(...column.map((rect) => rect.l));
+		const right = Math.max(...column.map((rect) => rect.r));
+		const at = passY(column, (y1 + y2) / 2, bottom);
+		const mid = x + (left - x) / 2;
+		d += ` C${mid} ${y} ${mid} ${at} ${left} ${at} L${right} ${at}`;
+		x = right;
+		y = at;
+	}
+	const mid = x + (b.l - x) / 2;
+	return `${d} C${mid} ${y} ${mid} ${y2} ${b.l} ${y2}`;
+}
+
 /**
  * カードの実寸から線を引き直す, 位置決めをブラウザに任せているので測るしかない
  * 実寸にはモーダルの開閉アニメーションのscaleが乗るので, SVGの座標系へ戻してから使う
@@ -72,19 +119,40 @@ function draw(): void {
 	if (!root || !base) return;
 	// 縮小中の値をそのまま置くと線が縮み, 端がカードから離れる
 	const scale = root.clientWidth > 0 ? base.width / root.clientWidth : 1;
-	const at = (x: number, y: number) => [(x - base.left) / scale, (y - base.top) / scale] as const;
+	const rectOf = (id: string): Rect | null => {
+		const element = cards.get(id);
+		if (!element) return null;
+		const r = element.getBoundingClientRect();
+		return {
+			l: (r.left - base.left) / scale,
+			r: (r.right - base.left) / scale,
+			t: (r.top - base.top) / scale,
+			b: (r.bottom - base.top) / scale,
+		};
+	};
+
+	const columnOf = new Map<string, number>();
+	const rects: Rect[][] = [];
+	columns.value.forEach((column, index) => {
+		rects[index] = [];
+		for (const node of column) {
+			columnOf.set(node.id, index);
+			const rect = rectOf(node.id);
+			if (rect) rects[index]!.push(rect);
+		}
+	});
+	const bottom = base.height / scale;
+
 	const next: string[] = [];
 	for (const node of roots.value) {
 		for (const from of node.after) {
-			const source = cards.get(from);
-			const target = cards.get(node.id);
-			if (!source || !target) continue;
-			const a = source.getBoundingClientRect();
-			const b = target.getBoundingClientRect();
-			const [x1, y1] = at(a.right, a.top + a.height / 2);
-			const [x2, y2] = at(b.left, b.top + b.height / 2);
-			const mid = x1 + (x2 - x1) / 2;
-			next.push(`M${x1} ${y1} C${mid} ${y1} ${mid} ${y2} ${x2} ${y2}`);
+			const a = rectOf(from);
+			const b = rectOf(node.id);
+			const source = columnOf.get(from);
+			const target = columnOf.get(node.id);
+			if (!a || !b || source === undefined || target === undefined) continue;
+			const between = rects.slice(source + 1, target).filter((column) => column.length > 0);
+			next.push(pathFor(a, b, between, bottom));
 		}
 	}
 	paths.value = next;

--- a/packages/tsumugi/src/do/run-repo.ts
+++ b/packages/tsumugi/src/do/run-repo.ts
@@ -1,8 +1,25 @@
-import { asc, eq, inArray, lte, sql } from 'drizzle-orm';
+import { asc, eq, getTableColumns, inArray, lte, sql } from 'drizzle-orm';
 import { drizzle, type DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
 import type { NodeOrigin, NodeState, NodeView, RunState } from '../core/run.js';
 import { applyRunSchema, type NodeRow, type RunRow } from './run-schema.js';
 import { node, run, runOutbox } from './run-tables.js';
+
+/** 1文に渡せるバインド変数の上限, 101個目でSQLITE_ERRORになる */
+const BIND_LIMIT = 100;
+
+const NODE_COLUMNS = Object.keys(getTableColumns(node)).length;
+const OUTBOX_COLUMNS = Object.keys(getTableColumns(runOutbox)).length;
+
+/**
+ * バインド変数の上限に収まる件数へ分ける
+ * fan-outの展開は件数が実行時に決まるので, 1文にまとめると上限を超える
+ */
+function chunk<T>(items: readonly T[], perItem: number): T[][] {
+	const size = Math.max(1, Math.floor(BIND_LIMIT / perItem));
+	const parts: T[][] = [];
+	for (let i = 0; i < items.length; i += size) parts.push(items.slice(i, i + size));
+	return parts;
+}
 
 export type NewNode = {
 	id: string;
@@ -108,7 +125,12 @@ export class RunRepo {
 	}
 
 	insertNodes(nodes: readonly NewNode[], now: number): void {
-		if (nodes.length === 0) return;
+		for (const part of chunk(nodes, NODE_COLUMNS)) {
+			this.#insertNodeChunk(part, now);
+		}
+	}
+
+	#insertNodeChunk(nodes: readonly NewNode[], now: number): void {
 		this.db
 			.insert(node)
 			.values(
@@ -169,13 +191,16 @@ export class RunRepo {
 
 	/** 写像関数へ渡す材料, 依存しているノードのぶんだけ引く */
 	resultsOf(ids: readonly string[]): Map<string, unknown> {
-		if (ids.length === 0) return new Map();
-		const rows = this.db
-			.select({ id: node.id, result: node.result })
-			.from(node)
-			.where(inArray(node.id, [...ids]))
-			.all();
-		return new Map(rows.map((row) => [row.id, row.result === null ? undefined : (JSON.parse(row.result) as unknown)]));
+		const results = new Map<string, unknown>();
+		for (const part of chunk(ids, 1)) {
+			const rows = this.db
+				.select({ id: node.id, result: node.result })
+				.from(node)
+				.where(inArray(node.id, [...part]))
+				.all();
+			for (const row of rows) results.set(row.id, row.result === null ? undefined : (JSON.parse(row.result) as unknown));
+		}
+		return results;
 	}
 
 	updateNode(id: string, patch: NodePatch, now: number): void {
@@ -268,7 +293,13 @@ export class RunRepo {
 	}
 
 	appendNodeOutbox(runId: string, ids: readonly string[]): void {
-		if (ids.length === 0) return;
+		// 追記側の列数で分ければ, 引く側のIDも上限に収まる
+		for (const part of chunk(ids, OUTBOX_COLUMNS)) {
+			this.#appendNodeOutboxChunk(runId, part);
+		}
+	}
+
+	#appendNodeOutboxChunk(runId: string, ids: readonly string[]): void {
 		const rows = this.db
 			.select()
 			.from(node)

--- a/packages/tsumugi/test/workers/run-repo-batch.test.ts
+++ b/packages/tsumugi/test/workers/run-repo-batch.test.ts
@@ -1,0 +1,62 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import type { TsumugiRunInstance } from '../../src/do/run.js';
+
+/**
+ * 一括の書き込みがバインド変数の上限に収まること
+ *
+ * 1文の変数は100個までで, 101個目でSQLITE_ERRORになる
+ * fan-outの展開もtickで触れたノードの追記も件数が実行時に決まるので, 分割しないと落ちる
+ */
+
+const ns = env.RUN as unknown as DurableObjectNamespace<TsumugiRunInstance>;
+
+const newNodes = (count: number) =>
+	Array.from({ length: count }, (_, i) => ({
+		id: `n${i}`,
+		binding: 'GREET',
+		container: false,
+		parent: null,
+		origin: 'static' as const,
+		after: [],
+		seq: i,
+	}));
+
+describe('一括の書き込みの分割', () => {
+	it('上限を超える件数のノードを作れる', async () => {
+		const stub = ns.get(ns.idFromName('BATCH:insert'));
+		const count = await runInDurableObject(stub, (instance) => {
+			const repo = (instance as any).repo;
+			repo.insertNodes(newNodes(120), 1);
+			return repo.countNodes() as number;
+		});
+		expect(count).toBe(120);
+	});
+
+	it('上限を超える件数のノードを投影へ積める', async () => {
+		const stub = ns.get(ns.idFromName('BATCH:outbox'));
+		const appended = await runInDurableObject(stub, (instance) => {
+			const repo = (instance as any).repo;
+			const nodes = newNodes(120);
+			repo.insertNodes(nodes, 1);
+			repo.appendNodeOutbox(
+				'BATCH:outbox',
+				nodes.map((n) => n.id),
+			);
+			return (repo.outboxBatch(200) as { target: string }[]).length;
+		});
+		expect(appended).toBe(120);
+	});
+
+	it('上限を超える件数の依存の戻り値を引ける', async () => {
+		const stub = ns.get(ns.idFromName('BATCH:results'));
+		const size = await runInDurableObject(stub, (instance) => {
+			const repo = (instance as any).repo;
+			const nodes = newNodes(120);
+			repo.insertNodes(nodes, 1);
+			for (const n of nodes) repo.updateNode(n.id, { result: JSON.stringify({ id: n.id }) }, 1);
+			return (repo.resultsOf(nodes.map((n) => n.id)) as Map<string, unknown>).size;
+		});
+		expect(size).toBe(120);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 依存関係を示すグラフの線が、途中のカードに接触しにくいよう自動的に迂回するようになりました。
  * 多数のノードや処理結果を扱う際も、データベースの制限を超えないよう分割処理され、安定性が向上しました。

* **テスト**
  * 大量データを扱うケースの動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->