### PR TITLE
feat: flowから別のflowを起動できるようにする

### DIFF
--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -11,7 +11,7 @@ class Hello extends Performer<{ name: string }, void, {}, Env> {
 /** リトライとバックオフを見るための必ず失敗するperformer */
 class Boom extends Performer<unknown, void, {}, Env> {
 	async perform(): Promise<void> {
-		throw new Error('意図的な失敗');
+		throw new Error('intentional failure');
 	}
 }
 

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -41,19 +41,26 @@ const performers = { HELLO: Hello, BOOM: Boom, LIST: ListNames, GREET: Greet, RE
 // flowの定義口をperformersから作る, bindingもpayloadもここから型が決まる(ADR-0030)
 const flow = createFlow(performers);
 
+// 一覧を取り, 件数だけ実行時に決まる並列で挨拶し, 最後に要約を書く
+const GREETINGS = flow<{ prefix: string }>((f) => {
+	const list = f.node('list', 'LIST', { input: (i) => ({ prefix: i.prefix }) });
+	const each = f.fanOut('greet', 'GREET', {
+		after: { list },
+		over: (_i, d) => d.list.names,
+		input: (name) => ({ name }),
+	});
+	f.node('report', 'REPORT', {
+		after: { each },
+		input: (_i, d) => ({ total: d.each.total, failed: d.each.failed }),
+	});
+});
+
 const flows = {
-	// 一覧を取り, 件数だけ実行時に決まる並列で挨拶し, 最後に要約を書く
-	GREETINGS: flow<{ prefix: string }>((f) => {
-		const list = f.node('list', 'LIST', { input: (i) => ({ prefix: i.prefix }) });
-		const each = f.fanOut('greet', 'GREET', {
-			after: { list },
-			over: (_i, d) => d.list.names,
-			input: (name) => ({ name }),
-		});
-		f.node('report', 'REPORT', {
-			after: { each },
-			input: (_i, d) => ({ total: d.each.total, failed: d.each.failed }),
-		});
+	GREETINGS,
+	// 子のrunとしてGREETINGSを起動し, その終端を待ってから要約する
+	PIPELINE: flow<{ prefix: string }>((f) => {
+		const greetings = f.subflow('greetings', GREETINGS, { input: (i) => ({ prefix: i.prefix }) });
+		f.node('summary', 'REPORT', { after: { greetings }, input: () => ({ total: 1, failed: 0 }) });
 	}),
 };
 

--- a/packages/dashboard/src/App.vue
+++ b/packages/dashboard/src/App.vue
@@ -377,6 +377,7 @@ const columnClass = (key: keyof typeof COLUMN) => (visible.value[key] ? COLUMN[k
 				selectedRun = null;
 				selected = $event;
 			"
+			@run="selectedRun = $event"
 		/>
 		<NewRunModal
 			:open="startingRun"

--- a/packages/dashboard/src/components/RunDetailModal.vue
+++ b/packages/dashboard/src/components/RunDetailModal.vue
@@ -6,7 +6,7 @@ import StatusCell from './StatusCell.vue';
 import { cancelRun, getRun, retryRun, type Run, type RunNode } from '../api';
 
 const props = defineProps<{ runId: string | null }>();
-const emit = defineEmits<{ close: []; changed: []; job: [jobId: string] }>();
+const emit = defineEmits<{ close: []; changed: []; job: [jobId: string]; run: [runId: string] }>();
 
 const run = ref<Run | null>(null);
 const nodes = ref<RunNode[]>([]);
@@ -133,7 +133,7 @@ const pretty = (input: string | undefined) => {
 
 							<div>
 								<p class="mb-1 text-muted-foreground">Graph</p>
-								<RunGraph :nodes="nodes" @select="emit('job', $event)" />
+								<RunGraph :nodes="nodes" @select="emit('job', $event)" @run="emit('run', $event)" />
 							</div>
 
 							<div>

--- a/packages/dashboard/src/components/RunDetailModal.vue
+++ b/packages/dashboard/src/components/RunDetailModal.vue
@@ -120,6 +120,18 @@ const pretty = (input: string | undefined) => {
 								<dd class="font-mono text-xs break-all">{{ run.id }}</dd>
 								<dt class="text-muted-foreground">Flow</dt>
 								<dd>{{ run.flow }}</dd>
+								<template v-if="run.parent_run_id">
+									<dt class="text-muted-foreground">Parent run</dt>
+									<dd>
+										<button
+											type="button"
+											class="border-none font-mono text-xs break-all underline underline-offset-2 hover:text-foreground"
+											@click="emit('run', run.parent_run_id)"
+										>
+											{{ run.parent_run_id }}
+										</button>
+									</dd>
+								</template>
 								<dt class="text-muted-foreground">Nodes</dt>
 								<dd class="tabular-nums">
 									{{ run.node_done }} / {{ run.node_total }}

--- a/packages/dashboard/src/components/RunGraph.vue
+++ b/packages/dashboard/src/components/RunGraph.vue
@@ -14,7 +14,7 @@ import type { RunNode } from '../api';
  * 実行時に増えたノードは親ノードの中に入る(ADR-0032)
  */
 const props = defineProps<{ nodes: RunNode[] }>();
-const emit = defineEmits<{ (event: 'select', jobId: string): void }>();
+const emit = defineEmits<{ (event: 'select', jobId: string): void; (event: 'run', runId: string): void }>();
 
 // カードの中身の実寸, 届くまでは`runLayout`の見積もりで置く
 const measured = ref(new Map<string, number>());
@@ -92,7 +92,7 @@ onNodesInitialized(() => {
 			:only-render-visible-elements="true"
 		>
 			<template #node-task="{ data }">
-				<RunTaskNode :data="data as TaskData" @select="emit('select', $event)" @measure="measure" />
+				<RunTaskNode :data="data as TaskData" @select="emit('select', $event)" @run="emit('run', $event)" @measure="measure" />
 			</template>
 			<template #node-child="{ data }">
 				<RunChildNode :data="data as ChildData" />

--- a/packages/dashboard/src/components/RunGraph.vue
+++ b/packages/dashboard/src/components/RunGraph.vue
@@ -103,16 +103,26 @@ onNodesInitialized(() => {
 		</VueFlow>
 
 		<div class="absolute right-2 bottom-2 flex gap-1">
-			<button type="button" class="rounded-card border border-border bg-background px-2 py-1 text-xs" aria-label="縮小" @click="zoomOut()">
+			<button
+				type="button"
+				class="rounded-card border border-border bg-background px-2 py-1 text-xs"
+				aria-label="Zoom out"
+				@click="zoomOut()"
+			>
 				-
 			</button>
-			<button type="button" class="rounded-card border border-border bg-background px-2 py-1 text-xs" aria-label="拡大" @click="zoomIn()">
+			<button
+				type="button"
+				class="rounded-card border border-border bg-background px-2 py-1 text-xs"
+				aria-label="Zoom in"
+				@click="zoomIn()"
+			>
 				+
 			</button>
 			<button
 				type="button"
 				class="rounded-card border border-border bg-background px-2 py-1 text-xs"
-				aria-label="全体を表示"
+				aria-label="Fit view"
 				@click="fitView({ padding: 0.15, maxZoom: 1 })"
 			>
 				Fit

--- a/packages/dashboard/src/components/graph/RunTaskNode.vue
+++ b/packages/dashboard/src/components/graph/RunTaskNode.vue
@@ -7,6 +7,7 @@ import { HANDLE_TOP, type TaskData } from './runLayout';
 const props = defineProps<{ data: TaskData }>();
 const emit = defineEmits<{
 	(event: 'select', jobId: string): void;
+	(event: 'run', runId: string): void;
 	(event: 'measure', id: string, height: number): void;
 }>();
 
@@ -59,6 +60,14 @@ onBeforeUnmount(() => observer?.disconnect());
 				@click="emit('select', node.job_id)"
 			>
 				Job
+			</button>
+			<button
+				v-if="node.child_run_id"
+				type="button"
+				class="nodrag nopan mt-2 block border-none text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+				@click="emit('run', node.child_run_id)"
+			>
+				Run
 			</button>
 			<!-- 描き切れない子は状態ごとの件数で出す(ADR-0035) -->
 			<p v-if="data.summary" class="mt-2 truncate text-xs tabular-nums text-muted-foreground">{{ data.summary }}</p>

--- a/packages/dashboard/test/unit/runLayout.test.ts
+++ b/packages/dashboard/test/unit/runLayout.test.ts
@@ -170,7 +170,7 @@ describe('Runのグラフの配置', () => {
 
 	it('子は親の箱の中に収まる', () => {
 		const children = Array.from({ length: 9 }, (_unused, i) => child('each', i));
-		const result = runLayout([node({ id: 'each', container: true, job_id: 'GREET#0:x', error: '意図的な失敗' }), ...children]);
+		const result = runLayout([node({ id: 'each', container: true, job_id: 'GREET#0:x', error: 'intentional failure' }), ...children]);
 
 		const parent = taskOf(result, 'each')!;
 		const width = Number.parseFloat(parent.style.width);

--- a/packages/tsumugi/migrations/0005_add_subflow.sql
+++ b/packages/tsumugi/migrations/0005_add_subflow.sql
@@ -1,0 +1,8 @@
+-- subflowノードが起動した子のrunID
+-- 画面から子のrunへ辿るために投影する
+ALTER TABLE run_node ADD COLUMN child_run_id TEXT;
+
+-- subflowとして起動されたrunの親
+-- 子のrunから親を辿るために投影する
+ALTER TABLE run ADD COLUMN parent_run_id TEXT;
+ALTER TABLE run ADD COLUMN parent_node_id TEXT;

--- a/packages/tsumugi/scripts/size-check.mjs
+++ b/packages/tsumugi/scripts/size-check.mjs
@@ -77,7 +77,7 @@ let failed = false;
 for (const [path, budget] of Object.entries(BUDGETS)) {
 	const files = closureOf(path);
 	if (files.length === 0) {
-		console.error(`✗ ${path}が見つからない(先にbuildが必要)`);
+		console.error(`✗ ${path} not found (build first)`);
 		failed = true;
 		continue;
 	}
@@ -86,33 +86,33 @@ for (const [path, budget] of Object.entries(BUDGETS)) {
 	const size = gzipSync(Buffer.from(source)).length;
 	const pct = Math.round((size / budget) * 100);
 	const externals = externalsOf(files);
-	const deps = externals.length > 0 ? `, 外部: ${externals.join(' ')}` : '';
+	const deps = externals.length > 0 ? `, external: ${externals.join(' ')}` : '';
 
 	if (size > budget) {
-		console.error(`✗ ${path} ${fmt(size)}/予算${fmt(budget)} (${pct}%) [${files.length}ファイル${deps}]`);
+		console.error(`✗ ${path} ${fmt(size)}/budget ${fmt(budget)} (${pct}%) [${files.length} files${deps}]`);
 		failed = true;
 	} else {
-		console.log(`✓ ${path} ${fmt(size)}/予算${fmt(budget)} (${pct}%) [${files.length}ファイル${deps}]`);
+		console.log(`✓ ${path} ${fmt(size)}/budget ${fmt(budget)} (${pct}%) [${files.length} files${deps}]`);
 	}
 
 	const allowed = ALLOWED_EXTERNALS[path] ?? [];
 	for (const dep of externals) {
 		if (!allowed.includes(dep)) {
-			console.error(`  ✗ 宣言していない外部依存: ${dep}`);
+			console.error(`  ✗ undeclared external dependency: ${dep}`);
 			failed = true;
 		}
 	}
 
 	for (const pattern of FORBIDDEN[path] ?? []) {
 		if (pattern.test(source)) {
-			console.error(`  ✗ 取り込まれてはならない実体がある: ${pattern}`);
+			console.error(`  ✗ found an implementation that must not be bundled: ${pattern}`);
 			failed = true;
 		}
 	}
 
 	for (const pattern of CANARY[path] ?? []) {
 		if (!pattern.test(source)) {
-			console.error(`  ✗ 印が見つからない,遮断の検査が形骸化している: ${pattern}`);
+			console.error(`  ✗ marker not found, the isolation check is no longer meaningful: ${pattern}`);
 			failed = true;
 		}
 	}

--- a/packages/tsumugi/src/api/access.ts
+++ b/packages/tsumugi/src/api/access.ts
@@ -108,7 +108,7 @@ export function clearJwksCache(): void {
 
 export function cloudflareAccess(options: AccessOptions): AuthMiddleware {
 	if (options.teamDomain.length === 0 || options.aud.length === 0) {
-		throw new Error('cloudflareAccessにはteamDomainとaudが必須, fail-closedの前提が崩れる');
+		throw new Error('cloudflareAccess requires teamDomain and aud, otherwise the fail-closed premise breaks');
 	}
 
 	return async (c, next) => {

--- a/packages/tsumugi/src/api/auth.ts
+++ b/packages/tsumugi/src/api/auth.ts
@@ -50,7 +50,7 @@ export type TokenResolver = (env: any) => string | undefined;
  * 解決できなければ通さない,設定漏れを素通りにしない(ADR-0013)
  */
 export function bearerAuth(token: string | TokenResolver, options: BearerOptions = {}): AuthMiddleware {
-	if (typeof token === 'string' && token.length === 0) throw new Error('bearerAuthのトークンが空, fail-closedの前提が崩れる');
+	if (typeof token === 'string' && token.length === 0) throw new Error('bearerAuth token is empty, the fail-closed premise breaks');
 
 	return async (c, next) => {
 		const expected = typeof token === 'string' ? token : token(c.env);

--- a/packages/tsumugi/src/api/openapi.ts
+++ b/packages/tsumugi/src/api/openapi.ts
@@ -125,9 +125,11 @@ const SCHEMAS: Record<string, unknown> = {
 		properties: {
 			...RUN_SUMMARY_PROPERTIES,
 			input: string('JSON-encoded string'),
+			parent_run_id: { ...nullable('string'), description: 'Set when this run was started by a subflow node.' },
+			parent_node_id: nullable('string'),
 			retryable: { type: 'boolean', description: 'Only failed runs can be resumed.' },
 		},
-		required: [...RUN_SUMMARY_REQUIRED, 'input', 'retryable'],
+		required: [...RUN_SUMMARY_REQUIRED, 'input', 'parent_run_id', 'parent_node_id', 'retryable'],
 	},
 	RunNode: {
 		type: 'object',
@@ -140,6 +142,7 @@ const SCHEMAS: Record<string, unknown> = {
 			origin: { type: 'string', enum: ['static', 'fanOut', 'spawn'] },
 			after: { type: 'array', items: string(), description: 'Node ids this node depends on' },
 			job_id: nullable('string'),
+			child_run_id: { ...nullable('string'), description: 'Set on subflow nodes, holding the run they started.' },
 			result: { ...nullable('string'), description: 'Set on fan-out nodes only, holding the child summary.' },
 			error: nullable('string'),
 			position: integer('Display order'),
@@ -155,6 +158,7 @@ const SCHEMAS: Record<string, unknown> = {
 			'origin',
 			'after',
 			'job_id',
+			'child_run_id',
 			'result',
 			'error',
 			'position',

--- a/packages/tsumugi/src/api/rest.ts
+++ b/packages/tsumugi/src/api/rest.ts
@@ -498,6 +498,9 @@ export function createRest<Env extends RestEnv>(auth: AuthMiddleware, options: R
 				node_failed: found.nodeFailed,
 				created_at: found.createdAt,
 				updated_at: found.updatedAt,
+				// subflowとして起動された場合の親, 画面から親のrunへ辿る
+				parent_run_id: found.parentRunId,
+				parent_node_id: found.parentNodeId,
 				// 終端でなければ再開できない, 押す前に可否を出す(ADR-0034)
 				retryable: found.state === 'FAILED',
 			},
@@ -510,6 +513,7 @@ export function createRest<Env extends RestEnv>(auth: AuthMiddleware, options: R
 				origin: node.origin,
 				after: parseAfter(node.after),
 				job_id: node.jobId,
+				child_run_id: node.childRunId,
 				result: node.result,
 				error: node.error,
 				position: node.position,

--- a/packages/tsumugi/src/api/types.ts
+++ b/packages/tsumugi/src/api/types.ts
@@ -82,6 +82,9 @@ export type RunSummary = {
 
 export type RunDetail = RunSummary & {
 	input: string;
+	/** subflowとして起動された場合の親, それ以外はnull */
+	parent_run_id: string | null;
+	parent_node_id: string | null;
 	/** 終端でなければ再開できない(ADR-0034) */
 	retryable: boolean;
 };
@@ -96,6 +99,8 @@ export type RunNodeView = {
 	origin: string;
 	after: string[];
 	job_id: string | null;
+	/** subflowノードが起動した子のrunID */
+	child_run_id: string | null;
 	/** fan-outノードの集計値のみが入る(ADR-0035) */
 	result: string | null;
 	error: string | null;

--- a/packages/tsumugi/src/config/fragment.ts
+++ b/packages/tsumugi/src/config/fragment.ts
@@ -20,14 +20,14 @@ const durableObjects = (entries: MissingBinding[]): string[] => {
 	const bindings = entries.map((entry) => ({ name: entry.name, class_name: entry.className ?? entry.name }));
 	return [
 		`"durable_objects": { "bindings": ${jsonc(bindings)} }`,
-		`// tagは既存と衝突しない番号へ振り直す\n"migrations": ${jsonc([{ tag: DO_MIGRATION_TAG, new_sqlite_classes: bindings.map((b) => b.class_name) }])}`,
+		`// renumber tag so it does not collide with existing ones\n"migrations": ${jsonc([{ tag: DO_MIGRATION_TAG, new_sqlite_classes: bindings.map((b) => b.class_name) }])}`,
 	];
 };
 
 const d1 = (entries: MissingBinding[]): string[] =>
 	entries.map(
 		(entry) =>
-			`// database_idは\`wrangler d1 create <name>\`の出力を貼る\n"d1_databases": ${jsonc([
+			`// paste database_id from the output of \`wrangler d1 create <name>\`\n"d1_databases": ${jsonc([
 				{
 					binding: entry.name,
 					database_name: '<database>',
@@ -52,7 +52,7 @@ const analytics = (entries: MissingBinding[]): string[] =>
 const services = (entries: MissingBinding[]): string[] => {
 	if (entries.length === 0) return [];
 	const list = entries.map((entry) => ({ binding: entry.name, service: '<worker>', entrypoint: '<PerformerClass>' }));
-	return [`// serviceとentrypointは相手のWorkerの名前とクラス名に合わせる\n"services": ${jsonc(list)}`];
+	return [`// set service and entrypoint to the target Worker name and class name\n"services": ${jsonc(list)}`];
 };
 
 const BUILDERS: Record<BindingKind, (entries: MissingBinding[]) => string[]> = {
@@ -85,19 +85,19 @@ const LABELS: Record<BindingKind, string> = {
  */
 export function configErrorMessage(missing: readonly MissingBinding[]): string {
 	const lines = missing.map((entry) => {
-		const detail = entry.reason === 'invalid' ? 'performerを持たない' : '未設定';
-		return `✗ ${entry.name} (${LABELS[entry.kind]}) が${detail}`;
+		const detail = entry.reason === 'invalid' ? 'has no performer' : 'is not configured';
+		return `✗ ${entry.name} (${LABELS[entry.kind]}) ${detail}`;
 	});
 
-	const next = ['wrangler.jsonc へ次の断片を追記する'];
+	const next = ['append the following fragment to wrangler.jsonc'];
 	if (missing.some((entry) => entry.kind === 'd1')) {
-		next.push('wrangler d1 create <database> でデータベースを作る');
-		next.push('wrangler d1 migrations apply <database> --remote で読み取りモデルを用意する');
+		next.push('run wrangler d1 create <database> to create the database');
+		next.push('run wrangler d1 migrations apply <database> --remote to set up the read model');
 	}
-	if (missing.some((entry) => entry.kind === 'queue')) next.push('wrangler queues create <queue> でキューを作る');
+	if (missing.some((entry) => entry.kind === 'queue')) next.push('run wrangler queues create <queue> to create the queue');
 
 	return [
-		'tsumugi: wranglerの設定が足りない',
+		'tsumugi: the wrangler configuration is incomplete',
 		...lines,
 		'',
 		...next.map((step, index) => `${index + 1}. ${step}`),

--- a/packages/tsumugi/src/core/flow.ts
+++ b/packages/tsumugi/src/core/flow.ts
@@ -153,13 +153,19 @@ export function shapeOf(flow: AnyFlow, nameOf?: (child: AnyFlow) => string | und
 		container: node.container,
 		// 同じ依存先を複数の受け取り口で受けた場合に重複するので畳む, 依存の数を数える側がずれる
 		after: [...new Set(Object.values(node.after))],
-		...(node.subflow ? { subflow: nameOf?.(node.subflow) ?? '' } : {}),
+		...(node.subflow ? { subflow: subflowNameOf(node.id, nameOf?.(node.subflow)) } : {}),
 	}));
+}
+
+/** 起動先のflow名、名前の無い形を保存するとrunIdを組み立てる時点まで誤りに気付けない */
+function subflowNameOf(nodeId: string, name: string | undefined): string {
+	if (!name) throw new InvalidFlowError(`subflow target is not registered: ${nodeId}`);
+	return name;
 }
 
 export function assertNodeId(id: string): void {
 	if (!NODE_ID_PATTERN.test(id)) {
-		throw new InvalidFlowError(`ノードIDが不正: ${JSON.stringify(id)} (英数字とハイフンとアンダースコアのみ)`);
+		throw new InvalidFlowError(`invalid node id: ${JSON.stringify(id)} (alphanumeric, hyphen and underscore only)`);
 	}
 }
 
@@ -189,11 +195,11 @@ export function createFlow<const R extends Record<string, unknown>>(_performers:
 
 		const register = (node: FlowNode): NodeRef<any> => {
 			assertNodeId(node.id);
-			if (seen.has(node.id)) throw new InvalidFlowError(`ノードIDが重複: ${node.id}`);
+			if (seen.has(node.id)) throw new InvalidFlowError(`duplicate node id: ${node.id}`);
 			seen.add(node.id);
 			// 宣言済みのノードしか変数で参照できないので,循環は構文的に起きない
 			for (const dependency of Object.values(node.after)) {
-				if (!seen.has(dependency)) throw new InvalidFlowError(`未宣言のノードに依存: ${node.id} -> ${dependency}`);
+				if (!seen.has(dependency)) throw new InvalidFlowError(`depends on an undeclared node: ${node.id} -> ${dependency}`);
 			}
 			nodes.push(node);
 			return { id: node.id };
@@ -241,7 +247,7 @@ export function createFlow<const R extends Record<string, unknown>>(_performers:
 		} as unknown as FlowBuilder<PerformersOf<R>, Input>;
 
 		build(builder);
-		if (nodes.length === 0) throw new InvalidFlowError('ノードが1つも宣言されていない');
+		if (nodes.length === 0) throw new InvalidFlowError('no nodes are declared');
 		return { nodes };
 	};
 }

--- a/packages/tsumugi/src/core/flow.ts
+++ b/packages/tsumugi/src/core/flow.ts
@@ -66,6 +66,12 @@ export type FanOutOptions<M extends Performers, K extends keyof M, Input, A exte
 	key?: (item: Item, index: number) => string;
 } & ConcurrencyKeyOption<ReqOf<M[K]>, (item: Item, index: number) => string>;
 
+/** 子のrunへ渡す入力を組み立てる, 戻り値の型は子のflowの入力に一致させる */
+export type SubflowOptions<Input, A extends Refs, ChildInput> = {
+	after?: A;
+	input: (input: Input, deps: DepsOf<A>) => ChildInput;
+};
+
 export type FlowBuilder<M extends Performers, Input> = {
 	node<K extends NodeBindings<M>, const A extends Refs = {}>(
 		id: string,
@@ -77,6 +83,15 @@ export type FlowBuilder<M extends Performers, Input> = {
 		binding: K,
 		options: FanOutOptions<M, K, Input, A, Item>,
 	): NodeRef<FanOutSummary>;
+	/**
+	 * 別のflowをrunとして起動し, 終端に達するまで待つ
+	 * 子の戻り値は受け取らない, runを跨ぐデータを増やさないため(ADR-0035)
+	 */
+	subflow<ChildInput, const A extends Refs = {}>(
+		id: string,
+		flow: Flow<ChildInput>,
+		options: SubflowOptions<Input, A, ChildInput>,
+	): NodeRef<void>;
 };
 
 /** 組み立て済みのノードが持つ関数,型引数を落として実行時の形に揃える */
@@ -105,6 +120,8 @@ export type FlowNode = {
 	key?: ChildKeyFn;
 	/** fan-outノードのみ, 子に渡す設定 */
 	childConcurrencyKey?: string | ChildKeyFn;
+	/** subflowノードのみ, 起動する子のflow定義 */
+	subflow?: AnyFlow;
 };
 
 export type Flow<Input = unknown> = {
@@ -122,16 +139,21 @@ export type Flows = Record<string, AnyFlow>;
 export type InputOf<F> = F extends Flow<infer I> ? I : never;
 
 /** Run DOへ保存するグラフの形(ADR-0030),関数は含まない */
-export type FlowShapeNode = { id: string; binding: string; container: boolean; after: readonly string[] };
+export type FlowShapeNode = { id: string; binding: string; container: boolean; after: readonly string[]; subflow?: string };
 export type FlowShape = readonly FlowShapeNode[];
 
-export function shapeOf(flow: AnyFlow): FlowShape {
+/**
+ * 保存する形へ落とす
+ * subflowノードは起動する子のflow名が要る, 名前はflow定義そのものからは引けないので外から渡す
+ */
+export function shapeOf(flow: AnyFlow, nameOf?: (child: AnyFlow) => string | undefined): FlowShape {
 	return flow.nodes.map((node) => ({
 		id: node.id,
 		binding: node.binding,
 		container: node.container,
 		// 同じ依存先を複数の受け取り口で受けた場合に重複するので畳む, 依存の数を数える側がずれる
 		after: [...new Set(Object.values(node.after))],
+		...(node.subflow ? { subflow: nameOf?.(node.subflow) ?? '' } : {}),
 	}));
 }
 
@@ -187,6 +209,18 @@ export function createFlow<const R extends Record<string, unknown>>(_performers:
 					job: jobOptionsOf(options as NodeJobOptions),
 					input: options.input as InputFn,
 					...(options.concurrencyKey !== undefined ? { concurrencyKey: options.concurrencyKey as string | ConcurrencyKeyFn } : {}),
+				});
+			},
+			subflow(id: string, child: AnyFlow, options: Record<string, any>) {
+				return register({
+					id,
+					// bindingはperformerを指さない, 画面には起動するflow名を出す
+					binding: '',
+					container: false,
+					after: refIds(options.after as Refs | undefined),
+					job: {},
+					input: options.input as InputFn,
+					subflow: child,
 				});
 			},
 			fanOut(id: string, binding: string, options: Record<string, any>) {

--- a/packages/tsumugi/src/core/ids.ts
+++ b/packages/tsumugi/src/core/ids.ts
@@ -24,13 +24,13 @@ export class InvalidJobIdError extends Error {
 
 export function assertValidBinding(binding: string): void {
 	if (!BINDING_PATTERN.test(binding)) {
-		throw new InvalidJobIdError(`binding名が不正: ${JSON.stringify(binding)} (英字またはアンダースコア始まりの英数字のみ)`);
+		throw new InvalidJobIdError(`invalid binding name: ${JSON.stringify(binding)} (alphanumeric, must start with a letter or underscore)`);
 	}
 }
 
 function assertValidShard(shard: number): void {
 	if (!Number.isInteger(shard) || shard < 0) {
-		throw new InvalidJobIdError(`shardが不正: ${shard} (0以上の整数)`);
+		throw new InvalidJobIdError(`invalid shard: ${shard} (non-negative integer)`);
 	}
 }
 
@@ -46,26 +46,26 @@ export function formatJobId(address: JobAddress): string {
 	assertValidBinding(binding);
 	assertValidShard(shard);
 	if (!LOCAL_ID_PATTERN.test(localId)) {
-		throw new InvalidJobIdError(`localIdが不正: ${JSON.stringify(localId)}`);
+		throw new InvalidJobIdError(`invalid localId: ${JSON.stringify(localId)}`);
 	}
 	return `${binding}#${shard}:${localId}`;
 }
 
 export function parseJobId(jobId: string): JobAddress {
 	const hash = jobId.indexOf('#');
-	if (hash < 0) throw new InvalidJobIdError(`#がない: ${JSON.stringify(jobId)}`);
+	if (hash < 0) throw new InvalidJobIdError(`missing "#": ${JSON.stringify(jobId)}`);
 	const colon = jobId.indexOf(':', hash + 1);
-	if (colon < 0) throw new InvalidJobIdError(`:がない: ${JSON.stringify(jobId)}`);
+	if (colon < 0) throw new InvalidJobIdError(`missing ":": ${JSON.stringify(jobId)}`);
 
 	const binding = jobId.slice(0, hash);
 	const shardText = jobId.slice(hash + 1, colon);
 	const localId = jobId.slice(colon + 1);
 
 	assertValidBinding(binding);
-	if (!/^\d+$/.test(shardText)) throw new InvalidJobIdError(`shardが数値でない: ${JSON.stringify(shardText)}`);
+	if (!/^\d+$/.test(shardText)) throw new InvalidJobIdError(`shard is not a number: ${JSON.stringify(shardText)}`);
 	const shard = Number(shardText);
 	assertValidShard(shard);
-	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidJobIdError(`localIdが不正: ${JSON.stringify(localId)}`);
+	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidJobIdError(`invalid localId: ${JSON.stringify(localId)}`);
 
 	return { binding, shard, localId };
 }
@@ -94,22 +94,23 @@ export class InvalidRunIdError extends Error {
 
 export function assertValidFlow(flow: string): void {
 	if (!FLOW_PATTERN.test(flow)) {
-		throw new InvalidRunIdError(`flow名が不正: ${JSON.stringify(flow)} (英数字とハイフンとアンダースコアのみ)`);
+		throw new InvalidRunIdError(`invalid flow name: ${JSON.stringify(flow)} (alphanumeric, hyphen and underscore only)`);
 	}
 }
 
 export function formatRunId({ flow, localId }: RunAddress): string {
-	if (!FLOW_PATTERN.test(flow)) throw new InvalidRunIdError(`flow名が不正: ${JSON.stringify(flow)} (英数字とハイフンとアンダースコアのみ)`);
-	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidRunIdError(`localIdが不正: ${JSON.stringify(localId)}`);
+	if (!FLOW_PATTERN.test(flow))
+		throw new InvalidRunIdError(`invalid flow name: ${JSON.stringify(flow)} (alphanumeric, hyphen and underscore only)`);
+	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidRunIdError(`invalid localId: ${JSON.stringify(localId)}`);
 	return `${flow}:${localId}`;
 }
 
 export function parseRunId(runId: string): RunAddress {
 	const colon = runId.indexOf(':');
-	if (colon < 0) throw new InvalidRunIdError(`:がない: ${JSON.stringify(runId)}`);
+	if (colon < 0) throw new InvalidRunIdError(`missing ":": ${JSON.stringify(runId)}`);
 	const flow = runId.slice(0, colon);
 	const localId = runId.slice(colon + 1);
-	if (!FLOW_PATTERN.test(flow)) throw new InvalidRunIdError(`flow名が不正: ${JSON.stringify(flow)}`);
-	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidRunIdError(`localIdが不正: ${JSON.stringify(localId)}`);
+	if (!FLOW_PATTERN.test(flow)) throw new InvalidRunIdError(`invalid flow name: ${JSON.stringify(flow)}`);
+	if (!LOCAL_ID_PATTERN.test(localId)) throw new InvalidRunIdError(`invalid localId: ${JSON.stringify(localId)}`);
 	return { flow, localId };
 }

--- a/packages/tsumugi/src/core/run.ts
+++ b/packages/tsumugi/src/core/run.ts
@@ -28,6 +28,8 @@ export type NodeView = {
 	state: NodeState;
 	/** fan-outノード, ジョブを持たず子の展開と集約のみを行う */
 	container: boolean;
+	/** subflowノード, ジョブを持たず子のrunの終端を待つ */
+	subflow: boolean;
 	/** 実行時に増えたノードの親,静的ノードはnull */
 	parent: string | null;
 	origin: NodeOrigin;
@@ -38,6 +40,8 @@ export type NodeView = {
 export type RunDecision =
 	/** ジョブを作って投入する */
 	| { type: 'start'; id: string }
+	/** 子のrunを開始する, 終端はその子からの通知で決まる */
+	| { type: 'startRun'; id: string }
 	/** fan-outノードの展開, overを評価して子を作る */
 	| { type: 'expand'; id: string }
 	/** fan-outノードの集約, 子孫が全て終端に達したので自身を終端へ進める */
@@ -137,6 +141,8 @@ export function advance({ nodes, cancelling }: AdvanceInput): AdvanceOutput {
 		if (cancelling) {
 			// QUEUED以降は取り消せていない場合に成功を返さない(ADR-0012), 送っても断られるので出さない
 			if (node.state === 'PENDING' || node.state === 'SCHEDULED') decisions.push({ type: 'cancel', id: node.id });
+			// 子のrunは実行中でも取り消せる, 親が終わった後も動き続けるのを防ぐ
+			else if (node.subflow && node.state === 'RUNNING') decisions.push({ type: 'cancel', id: node.id });
 			continue;
 		}
 
@@ -147,7 +153,8 @@ export function advance({ nodes, cancelling }: AdvanceInput): AdvanceOutput {
 			if (!missing && !deps.every((dep) => dep !== undefined && settled(dep))) continue;
 			const ready = !missing && deps.every((dep) => dep !== undefined && succeeded(dep));
 			if (!ready) decisions.push({ type: 'skip', id: node.id });
-			else decisions.push({ type: node.container ? 'expand' : 'start', id: node.id });
+			else if (node.container) decisions.push({ type: 'expand', id: node.id });
+			else decisions.push({ type: node.subflow ? 'startRun' : 'start', id: node.id });
 		}
 	}
 

--- a/packages/tsumugi/src/core/shard.ts
+++ b/packages/tsumugi/src/core/shard.ts
@@ -24,7 +24,9 @@ export function hashToShard(partitionKey: string, shards: number): number {
 export function resolveShard(binding: string, shards: number, partitionKey: string | undefined): number {
 	if (shards <= 1) return 0;
 	if (partitionKey === undefined) {
-		throw new InvalidJobIdError(`${binding}はshards=${shards}で分割されているためpartitionKeyが必須,省略するとキー単位の保証が失われる`);
+		throw new InvalidJobIdError(
+			`${binding} is split into shards=${shards} and requires partitionKey, omitting it drops the per-key guarantees`,
+		);
 	}
 	return hashToShard(partitionKey, shards);
 }

--- a/packages/tsumugi/src/core/transitions.ts
+++ b/packages/tsumugi/src/core/transitions.ts
@@ -42,7 +42,7 @@ export class InvalidTransitionError extends Error {
 		readonly from: JobState,
 		readonly to: JobState,
 	) {
-		super(`不正な状態遷移: ${from} -> ${to}`);
+		super(`invalid state transition: ${from} -> ${to}`);
 		this.name = 'InvalidTransitionError';
 	}
 }

--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -320,7 +320,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		const serialized = outcome.ok ? serializeResult(outcome.result) : null;
 		// runのノードでは戻り値が後段のpayloadの材料になる, 保存できないまま成功にすると気付かないままnullが下流へ渡る(ADR-0035)
 		if (outcome.ok && row.run_id !== null && outcome.result !== undefined && serialized === null) {
-			await this.report(jobId, { ok: false, error: `結果を保存できない(上限${RESULT_MAX_CHARS}文字または直列化不能)` });
+			await this.report(jobId, { ok: false, error: `cannot store the result (over ${RESULT_MAX_CHARS} chars or not serializable)` });
 			return;
 		}
 
@@ -540,7 +540,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		const namespace = this.env.RUN;
 		if (!namespace) {
 			// flowsを使うのにbindingが無い設定漏れ, 消さずに残して設定後に届くようにする(ADR-0013)
-			console.error('tsumugi: RUN binding が未設定のため完了通知を送れない');
+			console.error('tsumugi: cannot notify the run, RUN binding is not configured');
 			return 0;
 		}
 

--- a/packages/tsumugi/src/do/run-repo.ts
+++ b/packages/tsumugi/src/do/run-repo.ts
@@ -29,6 +29,8 @@ export type NewNode = {
 	origin: NodeOrigin;
 	after: readonly string[];
 	seq: number;
+	/** subflowノードのみ, 起動する子のflow名 */
+	subflow?: string;
 	/** 実行時に増えたノードだけが持つ, 静的ノードはflow定義から作る */
 	payload?: string;
 	options?: string;
@@ -37,6 +39,7 @@ export type NewNode = {
 export type NodePatch = {
 	state?: NodeState;
 	jobId?: string | null;
+	childRunId?: string | null;
 	result?: string | null;
 	error?: string | null;
 };
@@ -53,6 +56,9 @@ export type RunSnapshot = {
 	node_total: number;
 	node_done: number;
 	node_failed: number;
+	/** subflowとして起動された場合の親 */
+	parent_run_id: string | null;
+	parent_node_id: string | null;
 };
 
 export type NodeSnapshot = {
@@ -65,6 +71,8 @@ export type NodeSnapshot = {
 	origin: string;
 	after: string;
 	job_id: string | null;
+	/** subflowノードが起動した子のrunID */
+	child_run_id: string | null;
 	/**
 	 * fan-outノードの集計値のみを持たせる(ADR-0035)
 	 * 通常ノードの戻り値はジョブ側で投影済みなので, ここに持つと同じものを二度運ぶ
@@ -97,7 +105,15 @@ export class RunRepo {
 	}
 
 	/** 開始を1回に絞る, 同じrunIdは必ず同じDOに当たるので検査と挿入が不可分になる(ADR-0029) */
-	insertRun(input: { id: string; flow: string; input: string; shape: string; now: number }): boolean {
+	insertRun(input: {
+		id: string;
+		flow: string;
+		input: string;
+		shape: string;
+		now: number;
+		parent?: { runId: string; nodeId: string } | undefined;
+		depth?: number;
+	}): boolean {
 		const inserted = this.db
 			.insert(run)
 			.values({
@@ -107,6 +123,10 @@ export class RunRepo {
 				input: input.input,
 				shape: input.shape,
 				cancelling: 0,
+				parentRunId: input.parent?.runId ?? null,
+				parentNodeId: input.parent?.nodeId ?? null,
+				depth: input.depth ?? 0,
+				parentNotified: 0,
 				createdAt: input.now,
 				updatedAt: input.now,
 			})
@@ -118,6 +138,11 @@ export class RunRepo {
 
 	setRunState(id: string, state: RunState, now: number): void {
 		this.db.update(run).set({ state, updatedAt: now }).where(eq(run.id, id)).run();
+	}
+
+	/** 親へ終端を伝え終えた印, 立てるまで毎tickで再送する */
+	markParentNotified(id: string, now: number): void {
+		this.db.update(run).set({ parentNotified: 1, updatedAt: now }).where(eq(run.id, id)).run();
 	}
 
 	markCancelling(id: string, now: number): void {
@@ -144,7 +169,9 @@ export class RunRepo {
 					after: JSON.stringify(n.after),
 					payload: n.payload ?? null,
 					options: n.options ?? null,
+					subflow: n.subflow ?? null,
 					jobId: null,
+					childRunId: null,
 					result: null,
 					error: null,
 					seq: n.seq,
@@ -167,6 +194,7 @@ export class RunRepo {
 				id: node.id,
 				state: node.state,
 				container: node.container,
+				subflow: node.subflow,
 				parent: node.parent,
 				origin: node.origin,
 				after: node.after,
@@ -178,6 +206,7 @@ export class RunRepo {
 			id: row.id,
 			state: row.state as NodeState,
 			container: row.container === 1,
+			subflow: row.subflow !== null,
 			parent: row.parent,
 			origin: row.origin as NodeOrigin,
 			after: JSON.parse(row.after) as string[],
@@ -207,6 +236,7 @@ export class RunRepo {
 		const set: Record<string, unknown> = { updatedAt: now };
 		if (patch.state !== undefined) set.state = patch.state;
 		if (patch.jobId !== undefined) set.jobId = patch.jobId;
+		if (patch.childRunId !== undefined) set.childRunId = patch.childRunId;
 		if (patch.result !== undefined) set.result = patch.result;
 		if (patch.error !== undefined) set.error = patch.error;
 		this.db.update(node).set(set).where(eq(node.id, id)).run();
@@ -285,6 +315,8 @@ export class RunRepo {
 			node_total: total,
 			node_done: done,
 			node_failed: failed,
+			parent_run_id: row.parent_run_id,
+			parent_node_id: row.parent_node_id,
 		};
 		this.db
 			.insert(runOutbox)
@@ -320,6 +352,7 @@ export class RunRepo {
 						origin: row.origin,
 						after: row.after,
 						job_id: row.jobId,
+						child_run_id: row.childRunId,
 						result: row.container === 1 ? row.result : null,
 						error: row.error,
 						position: row.seq,
@@ -356,6 +389,10 @@ export class RunRepo {
 			input: row.input,
 			shape: row.shape,
 			cancelling: row.cancelling,
+			parent_run_id: row.parentRunId,
+			parent_node_id: row.parentNodeId,
+			depth: row.depth,
+			parent_notified: row.parentNotified,
 			created_at: row.createdAt,
 			updated_at: row.updatedAt,
 		};
@@ -372,7 +409,9 @@ export class RunRepo {
 			after: row.after,
 			payload: row.payload,
 			options: row.options,
+			subflow: row.subflow,
 			job_id: row.jobId,
+			child_run_id: row.childRunId,
 			result: row.result,
 			error: row.error,
 			seq: row.seq,

--- a/packages/tsumugi/src/do/run-repo.ts
+++ b/packages/tsumugi/src/do/run-repo.ts
@@ -251,12 +251,16 @@ export class RunRepo {
 	/**
 	 * 再開のために打ち切られたノードを起動前へ戻す(ADR-0034)
 	 * fan-outノードは子を作り直さず集約待ちへ戻す, 作り直すと成功済みの子も削除される
+	 * 子のrunIDも外す、残すと旧い子の遅れた通知が再開後の状態を上書きする
 	 */
 	resetForRetry(now: number): string[] {
+		// 親への通知済みの印を戻す、立てたままでは再開後の終端が親へ届かない
+		this.db.update(run).set({ parentNotified: 0, updatedAt: now }).run();
 		const cursor = this.sql.exec<{ id: string }>(
 			`UPDATE node SET
 				state = CASE WHEN container = 1 AND EXISTS(SELECT 1 FROM node child WHERE child.parent = node.id) THEN 'RUNNING' ELSE 'PENDING' END,
 				job_id = CASE WHEN container = 1 THEN job_id ELSE NULL END,
+				child_run_id = NULL,
 				error = NULL,
 				updated_at = ?
 			WHERE state IN ('FAILED', 'STALLED', 'SKIPPED', 'CANCELLED')

--- a/packages/tsumugi/src/do/run-schema.ts
+++ b/packages/tsumugi/src/do/run-schema.ts
@@ -13,6 +13,13 @@ export const RUN_SCHEMA = [
 		-- 開始時に固定したグラフの形(ADR-0030)
 		shape TEXT NOT NULL,
 		cancelling INTEGER NOT NULL DEFAULT 0,
+		-- subflowとして起動された場合の親, 終端に達した時点で親へ知らせる
+		parent_run_id TEXT,
+		parent_node_id TEXT,
+		-- 入れ子の深さ, 上限を超える起動を弾く
+		depth INTEGER NOT NULL DEFAULT 0,
+		-- 親へ終端を伝え終えたか, 失敗しても次のtickで再送する
+		parent_notified INTEGER NOT NULL DEFAULT 0,
 		created_at INTEGER NOT NULL,
 		updated_at INTEGER NOT NULL
 	)`,
@@ -28,6 +35,10 @@ export const RUN_SCHEMA = [
 		payload TEXT,
 		options TEXT,
 		job_id TEXT,
+		-- subflowノードが起動する子のflow名
+		subflow TEXT,
+		-- subflowノードが起動した子のrunID
+		child_run_id TEXT,
 		result TEXT,
 		error TEXT,
 		seq INTEGER NOT NULL,
@@ -48,6 +59,26 @@ export const RUN_SCHEMA = [
 
 export function applyRunSchema(sql: SqlStorage): void {
 	for (const statement of RUN_SCHEMA) sql.exec(statement);
+	// CREATE TABLE IF NOT EXISTSは既存テーブルを変更しない, 後から足した列を既存DOへ補う
+	for (const [table, column, type] of [
+		['run', 'parent_run_id', 'TEXT'],
+		['run', 'parent_node_id', 'TEXT'],
+		['run', 'depth', 'INTEGER NOT NULL DEFAULT 0'],
+		['run', 'parent_notified', 'INTEGER NOT NULL DEFAULT 0'],
+		['node', 'subflow', 'TEXT'],
+		['node', 'child_run_id', 'TEXT'],
+	] as const) {
+		ensureColumn(sql, table, column, type);
+	}
+}
+
+/** 既存の表に列が無ければ足す, 冪等にするため先に有無を確かめる */
+function ensureColumn(sql: SqlStorage, table: string, column: string, type: string): void {
+	const exists = sql
+		.exec<{ name: string }>(`SELECT name FROM pragma_table_info(?)`, table)
+		.toArray()
+		.some((row) => row.name === column);
+	if (!exists) sql.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
 }
 
 /** SQLiteの行そのまま, 射影はrun-repo.tsが担う */
@@ -58,6 +89,10 @@ export type RunRow = {
 	input: string;
 	shape: string;
 	cancelling: number;
+	parent_run_id: string | null;
+	parent_node_id: string | null;
+	depth: number;
+	parent_notified: number;
 	created_at: number;
 	updated_at: number;
 };
@@ -72,7 +107,9 @@ export type NodeRow = {
 	after: string;
 	payload: string | null;
 	options: string | null;
+	subflow: string | null;
 	job_id: string | null;
+	child_run_id: string | null;
 	result: string | null;
 	error: string | null;
 	seq: number;

--- a/packages/tsumugi/src/do/run-tables.ts
+++ b/packages/tsumugi/src/do/run-tables.ts
@@ -16,6 +16,13 @@ export const run = sqliteTable('run', {
 	shape: text('shape').notNull(),
 	/** 取り消しが要求された, 未起動を止めて実行中の終端を待つ */
 	cancelling: integer('cancelling').notNull().default(0),
+	/** subflowとして起動された場合の親 */
+	parentRunId: text('parent_run_id'),
+	parentNodeId: text('parent_node_id'),
+	/** 入れ子の深さ, 上限を超える起動を弾く */
+	depth: integer('depth').notNull().default(0),
+	/** 親へ終端を伝え終えたか */
+	parentNotified: integer('parent_notified').notNull().default(0),
 	createdAt: integer('created_at').notNull(),
 	updatedAt: integer('updated_at').notNull(),
 });
@@ -36,8 +43,12 @@ export const node = sqliteTable(
 		/** 実行時に増えたノードのpayloadと投入設定, 静的ノードはflow定義から作るのでnull */
 		payload: text('payload'),
 		options: text('options'),
+		/** subflowノードが起動する子のflow名 */
+		subflow: text('subflow'),
 		/** 最後に走ったジョブ, 再開で張り替わる(ADR-0034) */
 		jobId: text('job_id'),
+		/** subflowノードが起動した子のrunID */
+		childRunId: text('child_run_id'),
 		/** 後続のpayloadの材料, fan-outノードは集計値が入る(ADR-0035) */
 		result: text('result'),
 		error: text('error'),

--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -70,6 +70,9 @@ type SubflowStart = { nodeId: string; childRunId: string; flow: string; input: u
 /** ノード1件ぶんの投入内容, 宛先はRun DOが被せる */
 type BuiltJob = Omit<EnqueueInput, 'binding' | 'id' | 'runId' | 'nodeId' | 'partitionKey' | 'uniqueKey' | 'uniqueForMs'>;
 
+/** ノードのerror列へ入れる文言、stackは載せず理由だけを残す */
+const messageOf = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
 /** Job DOから見たRun DO, 通知だけを送る(ADR-0031) */
 export interface RunStub extends Rpc.DurableObjectBranded {
 	notify(events: readonly NodeEvent[]): Promise<void>;
@@ -155,11 +158,11 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			if (existing) return { id: runId, created: false };
 
 			const flow = flows[input.flow];
-			if (!flow) throw new Error(`flowが未登録: ${input.flow}`);
+			if (!flow) throw new Error(`flow is not registered: ${input.flow}`);
 
 			const depth = input.depth ?? 0;
 			// 深さの判定は起動された側で行う, 親が上限を知らなくても入れ子が止まる
-			if (depth > maxDepth) throw new Error(`subflowの入れ子が上限を超えた: ${maxDepth}`);
+			if (depth > maxDepth) throw new Error(`subflow nesting exceeded the limit: ${maxDepth}`);
 
 			const shape = shapeOf(flow, nameOf);
 			this.repo.insertRun({
@@ -236,7 +239,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			// 再開で子が張り替わっているなら古い便, 適用すると再実行の結果を上書きする(ADR-0034)
 			if (!row || row.child_run_id !== childRunId || state === 'RUNNING') return;
 
-			this.repo.updateNode(nodeId, { state, ...(state === 'FAILED' ? { error: `子のrunが失敗: ${childRunId}` } : {}) }, now);
+			this.repo.updateNode(nodeId, { state, ...(state === 'FAILED' ? { error: `child run failed: ${childRunId}` } : {}) }, now);
 			this.repo.appendNodeOutbox(run.id, [nodeId]);
 			await this.#armAlarm(now);
 		}
@@ -301,7 +304,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			const flow = flows[runRow.flow];
 			if (!flow) {
 				// 定義ごと消えた, 待っても解決しないので理由を残して落とす(ADR-0030)
-				this.#failRun(runRow.id, `flowが未登録: ${runRow.flow}`, now);
+				this.#failRun(runRow.id, `flow is not registered: ${runRow.flow}`, now);
 				await this.#project();
 				return;
 			}
@@ -342,15 +345,24 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 				await client.enqueueMany(this.env, inputs);
 			}
 			// 子のrunは同じIDで二度開始しても既存を返すので, 落ちた後の再実行で増えない(ADR-0029)
+			const unstarted = new Set<string>();
 			for (const child of subflows) {
-				await this.#runStub(child.childRunId).start({
-					flow: child.flow,
-					input: child.input,
-					parent: { runId: runRow.id, nodeId: child.nodeId },
-					depth: runRow.depth + 1,
-				});
+				try {
+					await this.#runStub(child.childRunId).start({
+						flow: child.flow,
+						input: child.input,
+						parent: { runId: runRow.id, nodeId: child.nodeId },
+						depth: runRow.depth + 1,
+					});
+				} catch (error) {
+					// 入れ子の上限超過などは待っても解決しない、落とさないとtickが同じ失敗を繰り返す
+					this.repo.updateNode(child.nodeId, { state: 'FAILED', error: `failed to start child run: ${messageOf(error)}` }, now);
+					unstarted.add(child.nodeId);
+					touched.add(child.nodeId);
+				}
 			}
 			for (const id of starting) {
+				if (unstarted.has(id)) continue;
 				// subflowノードは子の終端を待つ, ジョブと違いSCHEDULEDを経ない
 				this.repo.updateNode(id, { state: subflows.some((child) => child.nodeId === id) ? 'RUNNING' : 'SCHEDULED' }, now);
 				touched.add(id);
@@ -400,7 +412,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 				case 'start': {
 					const built = this.#buildJob(row, definitions, runInput);
 					if (!built) {
-						this.repo.updateNode(row.id, { state: 'FAILED', error: `ノードの定義が見つからない: ${row.id}` }, now);
+						this.repo.updateNode(row.id, { state: 'FAILED', error: `node definition is missing: ${row.id}` }, now);
 						return [row.id];
 					}
 					// 先にジョブIDを確保する, 投入だけ成功して落ちても同じIDで再投入すれば二重にならない
@@ -414,11 +426,18 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 				case 'startRun': {
 					const definition = definitions.get(row.id);
 					if (!definition?.subflow || row.subflow === null) {
-						this.repo.updateNode(row.id, { state: 'FAILED', error: `subflowの定義が見つからない: ${row.id}` }, now);
+						this.repo.updateNode(row.id, { state: 'FAILED', error: `subflow definition is missing: ${row.id}` }, now);
 						return [row.id];
 					}
 					// 子のrunIdは親のrunIdとノードIDから決まる, 再送しても同じ子に当たる(ADR-0029)
-					const childRunId = formatRunId({ flow: row.subflow, localId: `${parseRunId(runId).localId}-${row.id}` });
+					let childRunId: string;
+					try {
+						childRunId = formatRunId({ flow: row.subflow, localId: `${parseRunId(runId).localId}-${row.id}` });
+					} catch (error) {
+						// flow名が形として使えない、待っても解決しない
+						this.repo.updateNode(row.id, { state: 'FAILED', error: `invalid child run id: ${messageOf(error)}` }, now);
+						return [row.id];
+					}
 					if (row.child_run_id === null) this.repo.updateNode(row.id, { childRunId }, now);
 					starting.push(row.id);
 					subflows.push({
@@ -445,11 +464,9 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 
 				case 'cancel': {
 					if (row.child_run_id !== null) {
-						// 子は実行中でも取り消せる, 断られた場合は子の通知を待つ
-						const result = await this.#runStub(row.child_run_id).cancel();
-						if (!result.ok) return [];
-						this.repo.updateNode(row.id, { state: 'CANCELLED' }, now);
-						return [row.id];
+						// 子のcancelは要求の受理までで、終端に達したかは子からの通知で決まる
+						await this.#runStub(row.child_run_id).cancel();
+						return [];
 					}
 					if (row.job_id === null || row.state === 'PENDING') {
 						this.repo.updateNode(row.id, { state: 'CANCELLED' }, now);
@@ -468,13 +485,13 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 		#expand(row: NodeRow, definitions: Map<string, FlowNode>, runInput: unknown, now: number): string[] {
 			const definition = definitions.get(row.id);
 			if (!definition?.over || !definition.item) {
-				this.repo.updateNode(row.id, { state: 'FAILED', error: `fan-outの定義が見つからない: ${row.id}` }, now);
+				this.repo.updateNode(row.id, { state: 'FAILED', error: `fan-out definition is missing: ${row.id}` }, now);
 				return [row.id];
 			}
 
 			const items = definition.over(runInput, this.#depsOf(definition, runInput));
 			if (this.repo.countNodes() + items.length > maxNodes) {
-				this.repo.updateNode(row.id, { state: 'FAILED', error: `ノード数の上限を超えた: ${maxNodes}` }, now);
+				this.repo.updateNode(row.id, { state: 'FAILED', error: `node count exceeded the limit: ${maxNodes}` }, now);
 				return [row.id];
 			}
 
@@ -508,7 +525,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 		#applySpawns(parentId: string, spawns: readonly SpawnRequest[], now: number): string[] {
 			if (spawns.length === 0) return [];
 			if (this.repo.countNodes() + spawns.length > maxNodes) {
-				this.repo.updateNode(parentId, { state: 'FAILED', error: `ノード数の上限を超えた: ${maxNodes}` }, now);
+				this.repo.updateNode(parentId, { state: 'FAILED', error: `node count exceeded the limit: ${maxNodes}` }, now);
 				return [parentId];
 			}
 
@@ -577,14 +594,19 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			if (state === 'RUNNING') return true;
 			if (row.parent_notified === 1) return true;
 
-			await this.#runStub(row.parent_run_id).notifyChild(row.parent_node_id, row.id, state);
+			try {
+				await this.#runStub(row.parent_run_id).notifyChild(row.parent_node_id, row.id, state);
+			} catch (error) {
+				console.error('tsumugi: notifyParent failed', error);
+				return false;
+			}
 			this.repo.markParentNotified(row.id, now);
 			return true;
 		}
 
 		#runStub(runId: string): DurableObjectStub<RunPeerStub> {
 			const namespace = this.env.RUN as DurableObjectNamespace<RunPeerStub> | undefined;
-			if (!namespace) throw new Error('RUN binding が未設定, wranglerにRun DOのbindingを足す必要がある');
+			if (!namespace) throw new Error('RUN binding is not configured, add the Run DO binding to wrangler');
 			return namespace.get(namespace.idFromName(runId));
 		}
 

--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -3,8 +3,8 @@ import { createId } from '@paralleldrive/cuid2';
 import type { BindingConfig, ClientEnv } from '../client/enqueue.js';
 import { createClient } from '../client/enqueue.js';
 import { assertNodeId, type AnyFlow, type FlowNode, type Flows, type FlowShape, type NodeJobOptions, shapeOf } from '../core/flow.js';
-import { formatJobId, shardNameOf } from '../core/ids.js';
-import { advance, type NodeEvent, type NodeState, type RunDecision, type SpawnRequest } from '../core/run.js';
+import { formatJobId, formatRunId, parseRunId, shardNameOf } from '../core/ids.js';
+import { advance, type NodeEvent, type NodeState, type RunDecision, type RunState, type SpawnRequest } from '../core/run.js';
 import { resolveShard } from '../core/shard.js';
 import type { Retention } from '../core/types.js';
 import { systemClock, type Clock } from './clock.js';
@@ -13,7 +13,11 @@ import { projectRun } from '../projection/run-projector.js';
 import type { NodeRow } from './run-schema.js';
 import { RunRepo } from './run-repo.js';
 
-export type RunEnv = ClientEnv & { TSUMUGI_DB: D1Database };
+export type RunEnv = ClientEnv & {
+	TSUMUGI_DB: D1Database;
+	/** subflowを使う場合のみ必要, 子と親のrunを引く */
+	RUN?: DurableObjectNamespace<any>;
+};
 
 /** 1回のtickで扱うノードの上限, alarmのwall timeを有界にする */
 const TICK_LIMIT = 200;
@@ -27,6 +31,12 @@ const PROJECTION_LIMIT = 200;
 /** 1つのrunに入るノード数の既定上限(ADR-0035) */
 export const DEFAULT_MAX_NODES = 10_000;
 
+/**
+ * subflowの入れ子の既定上限
+ * ノード数の上限は親と子で別々に数えるので, 深さ側にも上限が要る(ADR-0035)
+ */
+export const DEFAULT_MAX_DEPTH = 3;
+
 /** 済んだrunをDOに残す時間,投影が追いつく余裕を見て既定5分(ADR-0034) */
 const DEFAULT_SWEEP_AFTER_MS = 5 * 60 * 1000;
 
@@ -36,14 +46,26 @@ const DEFAULT_FAILED_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 export type RunSettings = {
 	/** 1つのrunに入るノード数の上限(ADR-0035) */
 	maxNodes?: number;
+	/** subflowの入れ子の上限, 既定は3 */
+	maxDepth?: number;
 	/** 済んだrun(COMPLETED / CANCELLED)をDOに残す時間 */
 	sweepAfterMs?: number;
 	/** 失敗したrunをDOに残す時間, 手動再開を受け付ける期間 */
 	failedRetentionMs?: number;
 };
 
-export type StartInput = { flow: string; input: unknown };
+export type StartInput = {
+	flow: string;
+	input: unknown;
+	/** subflowとして起動された場合の親, 終端に達した時点で知らせる先 */
+	parent?: { runId: string; nodeId: string };
+	/** 入れ子の深さ, 親から受け取る */
+	depth?: number;
+};
 export type StartResult = { id: string; created: boolean };
+
+/** 1 tickで開始する子のrun */
+type SubflowStart = { nodeId: string; childRunId: string; flow: string; input: unknown };
 
 /** ノード1件ぶんの投入内容, 宛先はRun DOが被せる */
 type BuiltJob = Omit<EnqueueInput, 'binding' | 'id' | 'runId' | 'nodeId' | 'partitionKey' | 'uniqueKey' | 'uniqueForMs'>;
@@ -51,6 +73,16 @@ type BuiltJob = Omit<EnqueueInput, 'binding' | 'id' | 'runId' | 'nodeId' | 'part
 /** Job DOから見たRun DO, 通知だけを送る(ADR-0031) */
 export interface RunStub extends Rpc.DurableObjectBranded {
 	notify(events: readonly NodeEvent[]): Promise<void>;
+}
+
+/**
+ * 親と子の間で使うRun DOの面
+ * DO本体の型を通すと型の展開が深くなりすぎるので, 使う分だけを宣言する
+ */
+export interface RunPeerStub extends Rpc.DurableObjectBranded {
+	start(input: StartInput): Promise<StartResult>;
+	cancel(): Promise<MutationResult>;
+	notifyChild(nodeId: string, childRunId: string, state: RunState): Promise<void>;
 }
 
 /**
@@ -62,6 +94,7 @@ export interface TsumugiRunInstance extends Rpc.DurableObjectBranded {
 	clock: Clock;
 	start(input: StartInput): Promise<StartResult>;
 	notify(events: readonly NodeEvent[]): Promise<void>;
+	notifyChild(nodeId: string, childRunId: string, state: RunState): Promise<void>;
 	cancel(): Promise<MutationResult>;
 	retry(): Promise<MutationResult>;
 	alarm(): Promise<void>;
@@ -84,6 +117,9 @@ export type RunOptions = {
  */
 export function createRunClass({ flows, bindings, settings = {} }: RunOptions): RunClass {
 	const maxNodes = settings.maxNodes ?? DEFAULT_MAX_NODES;
+	const maxDepth = settings.maxDepth ?? DEFAULT_MAX_DEPTH;
+	// flow定義から名前を引く, subflowノードは定義そのものを持つのでここで名前へ落とす
+	const nameOf = (child: AnyFlow) => Object.keys(flows).find((name) => flows[name] === child);
 	const retention: Retention = {
 		doneMs: settings.sweepAfterMs ?? DEFAULT_SWEEP_AFTER_MS,
 		failedMs: settings.failedRetentionMs ?? DEFAULT_FAILED_RETENTION_MS,
@@ -121,8 +157,20 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			const flow = flows[input.flow];
 			if (!flow) throw new Error(`flowが未登録: ${input.flow}`);
 
-			const shape = shapeOf(flow);
-			this.repo.insertRun({ id: runId, flow: input.flow, input: JSON.stringify(input.input ?? null), shape: JSON.stringify(shape), now });
+			const depth = input.depth ?? 0;
+			// 深さの判定は起動された側で行う, 親が上限を知らなくても入れ子が止まる
+			if (depth > maxDepth) throw new Error(`subflowの入れ子が上限を超えた: ${maxDepth}`);
+
+			const shape = shapeOf(flow, nameOf);
+			this.repo.insertRun({
+				id: runId,
+				flow: input.flow,
+				input: JSON.stringify(input.input ?? null),
+				shape: JSON.stringify(shape),
+				now,
+				parent: input.parent,
+				depth,
+			});
 			this.repo.insertNodes(
 				shape.map((node, index) => ({
 					id: node.id,
@@ -132,6 +180,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 					origin: 'static' as const,
 					after: node.after,
 					seq: index,
+					...(node.subflow !== undefined ? { subflow: node.subflow } : {}),
 				})),
 				now,
 			);
@@ -172,6 +221,24 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 				this.repo.appendNodeOutbox(runId, touched);
 				await this.#armAlarm(now);
 			}
+		}
+
+		/**
+		 * 子のrunからの終端の通知
+		 * 子の状態をそのままノードの状態にする, 戻り値は受け取らない(ADR-0035)
+		 */
+		async notifyChild(nodeId: string, childRunId: string, state: RunState): Promise<void> {
+			const now = this.clock.now();
+			const run = this.repo.findRun();
+			if (!run) return;
+
+			const row = this.repo.findNode(nodeId);
+			// 再開で子が張り替わっているなら古い便, 適用すると再実行の結果を上書きする(ADR-0034)
+			if (!row || row.child_run_id !== childRunId || state === 'RUNNING') return;
+
+			this.repo.updateNode(nodeId, { state, ...(state === 'FAILED' ? { error: `子のrunが失敗: ${childRunId}` } : {}) }, now);
+			this.repo.appendNodeOutbox(run.id, [nodeId]);
+			await this.#armAlarm(now);
 		}
 
 		/** 画面とREST APIからの取り消し, 未起動を止めて実行中の終端を待つ */
@@ -246,6 +313,7 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			const touched = new Set<string>();
 			const inputs: EnqueueInput[] = [];
 			const starting: string[] = [];
+			const subflows: SubflowStart[] = [];
 			// この tick で既に決めたノード, 投入はまとめて行うので判断済みでもPENDINGのまま残る
 			const handled = new Set<string>();
 			let deferred = 0;
@@ -265,17 +333,27 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 
 				for (const decision of fresh.slice(0, room)) {
 					handled.add(decision.id);
-					const applied = await this.#apply(decision, { definitions, runInput, runId: runRow.id, now, inputs, starting });
+					const applied = await this.#apply(decision, { definitions, runInput, runId: runRow.id, now, inputs, starting, subflows });
 					for (const id of applied) touched.add(id);
 				}
 			}
 
 			if (inputs.length > 0) {
 				await client.enqueueMany(this.env, inputs);
-				for (const id of starting) {
-					this.repo.updateNode(id, { state: 'SCHEDULED' }, now);
-					touched.add(id);
-				}
+			}
+			// 子のrunは同じIDで二度開始しても既存を返すので, 落ちた後の再実行で増えない(ADR-0029)
+			for (const child of subflows) {
+				await this.#runStub(child.childRunId).start({
+					flow: child.flow,
+					input: child.input,
+					parent: { runId: runRow.id, nodeId: child.nodeId },
+					depth: runRow.depth + 1,
+				});
+			}
+			for (const id of starting) {
+				// subflowノードは子の終端を待つ, ジョブと違いSCHEDULEDを経ない
+				this.repo.updateNode(id, { state: subflows.some((child) => child.nodeId === id) ? 'RUNNING' : 'SCHEDULED' }, now);
+				touched.add(id);
 			}
 
 			// 決定を反映した後の姿で状態を決める, 反映前だと1tick古い状態を投影する
@@ -290,11 +368,13 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 			this.repo.appendNodeOutbox(runRow.id, [...touched]);
 
 			const projected = await this.#project();
-			if (await this.#sweep(now)) return;
+			const notified = await this.#notifyParent(settled.state, now);
+			if (notified && (await this.#sweep(now))) return;
 
 			// 打ち切った決定と投影の残りがあるうちは休まない
 			// 投影待ちも見る, tickのawait中に入った通知は投影されないまま残る
-			const hasMore = deferred > 0 || projected >= PROJECTION_LIMIT || settled.decisions.length > 0 || this.repo.countOutbox() > 0;
+			const hasMore =
+				deferred > 0 || projected >= PROJECTION_LIMIT || settled.decisions.length > 0 || this.repo.countOutbox() > 0 || !notified;
 			if (hasMore) await this.#armAlarm(now);
 			else await this.#armSweep(now);
 		}
@@ -309,9 +389,10 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 				now: number;
 				inputs: EnqueueInput[];
 				starting: string[];
+				subflows: SubflowStart[];
 			},
 		): Promise<string[]> {
-			const { definitions, runInput, runId, now, inputs, starting } = context;
+			const { definitions, runInput, runId, now, inputs, starting, subflows } = context;
 			const row = this.repo.findNode(decision.id);
 			if (!row) return [];
 
@@ -330,6 +411,25 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 					return [row.id];
 				}
 
+				case 'startRun': {
+					const definition = definitions.get(row.id);
+					if (!definition?.subflow || row.subflow === null) {
+						this.repo.updateNode(row.id, { state: 'FAILED', error: `subflowの定義が見つからない: ${row.id}` }, now);
+						return [row.id];
+					}
+					// 子のrunIdは親のrunIdとノードIDから決まる, 再送しても同じ子に当たる(ADR-0029)
+					const childRunId = formatRunId({ flow: row.subflow, localId: `${parseRunId(runId).localId}-${row.id}` });
+					if (row.child_run_id === null) this.repo.updateNode(row.id, { childRunId }, now);
+					starting.push(row.id);
+					subflows.push({
+						nodeId: row.id,
+						childRunId,
+						flow: row.subflow,
+						input: definition.input(runInput, this.#depsOf(definition, runInput)),
+					});
+					return [row.id];
+				}
+
 				case 'expand':
 					return this.#expand(row, definitions, runInput, now);
 
@@ -344,6 +444,13 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 					return [row.id];
 
 				case 'cancel': {
+					if (row.child_run_id !== null) {
+						// 子は実行中でも取り消せる, 断られた場合は子の通知を待つ
+						const result = await this.#runStub(row.child_run_id).cancel();
+						if (!result.ok) return [];
+						this.repo.updateNode(row.id, { state: 'CANCELLED' }, now);
+						return [row.id];
+					}
 					if (row.job_id === null || row.state === 'PENDING') {
 						this.repo.updateNode(row.id, { state: 'CANCELLED' }, now);
 						return [row.id];
@@ -457,6 +564,28 @@ export function createRunClass({ flows, bindings, settings = {} }: RunOptions): 
 		#shardOf(binding: string, runId: string): number {
 			// runIdをpartitionKeyにする, run内のノードが同じshardに集まりRun DO側でIDを決められる(ADR-0011)
 			return resolveShard(binding, bindings[binding]?.shards ?? 1, runId);
+		}
+
+		/**
+		 * 終端に達したことを親のrunへ知らせる
+		 * 送信に失敗した場合は印を立てずに次のtickで再送する
+		 * 親を持たないrunと未達のrunはtrueを返す, 掃除を止める理由が無い
+		 */
+		async #notifyParent(state: RunState, now: number): Promise<boolean> {
+			const row = this.repo.findRun();
+			if (!row || row.parent_run_id === null || row.parent_node_id === null) return true;
+			if (state === 'RUNNING') return true;
+			if (row.parent_notified === 1) return true;
+
+			await this.#runStub(row.parent_run_id).notifyChild(row.parent_node_id, row.id, state);
+			this.repo.markParentNotified(row.id, now);
+			return true;
+		}
+
+		#runStub(runId: string): DurableObjectStub<RunPeerStub> {
+			const namespace = this.env.RUN as DurableObjectNamespace<RunPeerStub> | undefined;
+			if (!namespace) throw new Error('RUN binding が未設定, wranglerにRun DOのbindingを足す必要がある');
+			return namespace.get(namespace.idFromName(runId));
 		}
 
 		#jobStub(jobId: string): DurableObjectStub<TsumugiJobShard> {

--- a/packages/tsumugi/src/projection/migrations.ts
+++ b/packages/tsumugi/src/projection/migrations.ts
@@ -15,6 +15,7 @@ export const EXPECTED_MIGRATIONS = [
 	'0002_add_attempt_log.sql',
 	'0003_add_result.sql',
 	'0004_create_run_read_model.sql',
+	'0005_add_subflow.sql',
 ] as const;
 
 /**

--- a/packages/tsumugi/src/projection/run-projector.ts
+++ b/packages/tsumugi/src/projection/run-projector.ts
@@ -23,6 +23,8 @@ function toRunValues(snapshot: RunSnapshot, seq: number): typeof run.$inferInser
 		nodeFailed: snapshot.node_failed,
 		createdAt: snapshot.created_at,
 		updatedAt: snapshot.updated_at,
+		parentRunId: snapshot.parent_run_id,
+		parentNodeId: snapshot.parent_node_id,
 	};
 }
 
@@ -38,6 +40,7 @@ function toNodeValues(snapshot: NodeSnapshot, seq: number): typeof runNode.$infe
 		origin: snapshot.origin,
 		after: snapshot.after,
 		jobId: snapshot.job_id,
+		childRunId: snapshot.child_run_id,
 		result: snapshot.result,
 		error: snapshot.error,
 		position: snapshot.position,

--- a/packages/tsumugi/src/projection/run-tables.ts
+++ b/packages/tsumugi/src/projection/run-tables.ts
@@ -20,6 +20,9 @@ export const run = sqliteTable(
 		nodeFailed: integer('node_failed').notNull(),
 		createdAt: integer('created_at').notNull(),
 		updatedAt: integer('updated_at').notNull(),
+		/** subflowとして起動された場合の親 */
+		parentRunId: text('parent_run_id'),
+		parentNodeId: text('parent_node_id'),
 	},
 	(t) => [
 		index('run_state').on(t.state, t.updatedAt),
@@ -43,6 +46,8 @@ export const runNode = sqliteTable(
 		origin: text('origin').notNull(),
 		after: text('after').notNull(),
 		jobId: text('job_id'),
+		/** subflowノードが起動した子のrunID */
+		childRunId: text('child_run_id'),
 		/** fan-outノードの集計値のみが入る,通常ノードの戻り値はjob表に投影済み(ADR-0035) */
 		result: text('result'),
 		error: text('error'),

--- a/packages/tsumugi/src/queue/consumer.ts
+++ b/packages/tsumugi/src/queue/consumer.ts
@@ -25,7 +25,7 @@ export class TsumugiTimeoutError extends Error {
 		readonly jobId: string,
 		readonly timeoutMs: number,
 	) {
-		super(`ジョブがタイムアウトした(${jobId}, ${timeoutMs}ms)`);
+		super(`job timed out (${jobId}, ${timeoutMs}ms)`);
 		this.name = 'TsumugiTimeoutError';
 	}
 }
@@ -107,7 +107,7 @@ async function handleOne<Env extends ConsumerEnv>(
 		// 分割代入もtryに入れる, 本文がnull等で壊れていても例外がackを飛ばさない(ADR-0004)
 		const body = message.body;
 		// jobIdが無い/文字列でない本文はここで弾く, performer実行とreportの対象にしない
-		if (typeof body?.jobId !== 'string') throw new Error('dispatchメッセージが不正: jobIdが無い');
+		if (typeof body?.jobId !== 'string') throw new Error('invalid dispatch message: jobId is missing');
 		jobId = body.jobId;
 		const { binding, attempt, payload, timeoutMs, claimRequired } = body;
 
@@ -118,13 +118,13 @@ async function handleOne<Env extends ConsumerEnv>(
 		}
 
 		const entry = performers[binding];
-		if (!entry) throw new Error(`performerが未登録: ${binding}`);
+		if (!entry) throw new Error(`performer is not registered: ${binding}`);
 		const base = { jobId, attempt, idempotencyKey: jobId };
 
 		if (isRemoteRef(entry)) {
 			const service = (env as Record<string, unknown>)[entry.binding] as RemotePerformerService | undefined;
 			// 設定漏れは即時失敗にする, 捕捉して無視すると検知できないまま失敗が続く
-			if (typeof service?.perform !== 'function') throw new Error(`service bindingが未設定: ${entry.binding}`);
+			if (typeof service?.perform !== 'function') throw new Error(`service binding is not configured: ${entry.binding}`);
 			// signalもspawnも非対応, 呼び出し中だけ有効なものはリモートへ渡さない(ADR-0026)
 			result = await withTimeout(jobId, timeoutMs, () => Promise.resolve(service.perform(payload, base)));
 		} else {

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -112,6 +112,13 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 	const flows: Flows = config.flows ?? {};
 	// flow名はrunIdの一部になる, 起動時に弾かないと開始まで誤りに気付けない(ADR-0029)
 	for (const flow of Object.keys(flows)) assertValidFlow(flow);
+	// subflowの起動先が`flows`に無いと子のrunIdを決められない, 同じく起動時に弾く
+	const registered = new Set(Object.values(flows));
+	for (const [name, flow] of Object.entries(flows)) {
+		for (const node of flow.nodes) {
+			if (node.subflow && !registered.has(node.subflow)) throw new Error(`subflowの起動先が未登録: ${name}.${node.id}`);
+		}
+	}
 
 	/** 設定漏れは開始時にエラーにする, エラーにしないとノードが永久に実行されない(ADR-0013) */
 	const runFor = (env: Env, runId: string): DurableObjectStub<RunControl> => {

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -116,19 +116,19 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 	const registered = new Set(Object.values(flows));
 	for (const [name, flow] of Object.entries(flows)) {
 		for (const node of flow.nodes) {
-			if (node.subflow && !registered.has(node.subflow)) throw new Error(`subflowの起動先が未登録: ${name}.${node.id}`);
+			if (node.subflow && !registered.has(node.subflow)) throw new Error(`subflow target is not registered: ${name}.${node.id}`);
 		}
 	}
 
 	/** 設定漏れは開始時にエラーにする, エラーにしないとノードが永久に実行されない(ADR-0013) */
 	const runFor = (env: Env, runId: string): DurableObjectStub<RunControl> => {
 		const namespace = env.RUN;
-		if (!namespace) throw new Error('RUN binding が未設定, wranglerにRun DOのbindingを足す必要がある');
+		if (!namespace) throw new Error('RUN binding is not configured, add the Run DO binding to wrangler');
 		return namespace.get(namespace.idFromName(runId));
 	};
 
 	const start = async (env: Env, flow: string, input: unknown, options?: { id?: string }): Promise<string> => {
-		if (!flows[flow]) throw new Error(`flowが未登録: ${flow}`);
+		if (!flows[flow]) throw new Error(`flow is not registered: ${flow}`);
 		const runId = formatRunId({ flow, localId: options?.id ?? createId() });
 		const result = await runFor(env, runId).start({ flow, input });
 		return result.id;

--- a/packages/tsumugi/test/unit/config-validate.test.ts
+++ b/packages/tsumugi/test/unit/config-validate.test.ts
@@ -159,10 +159,10 @@ describe('設定断片の生成', () => {
 describe('設定漏れの説明', () => {
 	it('不足の一覧と次に実行するコマンドを含む', () => {
 		const status = validateConfig({}, { performers });
-		if (status.ok) throw new Error('不足しているはず');
+		if (status.ok) throw new Error('expected a missing binding');
 		const message = configErrorMessage(status.missing);
 
-		expect(message).toContain('✗ TSUMUGI_DB (D1) が未設定');
+		expect(message).toContain('✗ TSUMUGI_DB (D1) is not configured');
 		expect(message).toContain('wrangler d1 create');
 		expect(message).toContain('wrangler d1 migrations apply');
 		expect(message).toContain('wrangler queues create');
@@ -173,7 +173,7 @@ describe('設定漏れの説明', () => {
 		const env = complete();
 		delete (env as Record<string, unknown>).TSUMUGI_QUEUE;
 		const status = validateConfig(env, { performers });
-		if (status.ok) throw new Error('不足しているはず');
+		if (status.ok) throw new Error('expected a missing binding');
 
 		const message = configErrorMessage(status.missing);
 		expect(message).toContain('wrangler queues create');
@@ -182,7 +182,7 @@ describe('設定漏れの説明', () => {
 
 	it('performerを持たないservice bindingは理由を分ける', () => {
 		const status = validateConfig({ ...complete(), MAIL_SERVICE: {} }, { performers: withRemote });
-		if (status.ok) throw new Error('不足しているはず');
-		expect(configErrorMessage(status.missing)).toContain('performerを持たない');
+		if (status.ok) throw new Error('expected a missing binding');
+		expect(configErrorMessage(status.missing)).toContain('has no performer');
 	});
 });

--- a/packages/tsumugi/test/unit/run.test.ts
+++ b/packages/tsumugi/test/unit/run.test.ts
@@ -8,12 +8,14 @@ type NodeSpec = {
 	parent?: string;
 	origin?: NodeView['origin'];
 	container?: boolean;
+	subflow?: boolean;
 };
 
 const node = (n: NodeSpec): NodeView => ({
 	id: n.id,
 	state: n.state,
 	container: n.container ?? false,
+	subflow: n.subflow ?? false,
 	parent: n.parent ?? null,
 	origin: n.origin ?? 'static',
 	after: n.after ?? [],
@@ -183,5 +185,39 @@ describe('runの状態', () => {
 
 	it('取り消しは全て終端になった時点でCANCELLED', () => {
 		expect(stateOf([node({ id: 'a', state: 'CANCELLED' })], true)).toBe('CANCELLED');
+	});
+});
+
+describe('subflowノード', () => {
+	it('依存が揃うと子のrunの開始を要求する', () => {
+		const nodes = [node({ id: 'list', state: 'COMPLETED' }), node({ id: 'child', state: 'PENDING', subflow: true, after: ['list'] })];
+		expect(advance({ nodes, cancelling: false }).decisions).toEqual([{ type: 'startRun', id: 'child' }]);
+	});
+
+	it('ジョブの投入は要求しない', () => {
+		// performerを持たないので, startを出すとJob DOへ空のbindingが渡る
+		const nodes = [node({ id: 'child', state: 'PENDING', subflow: true })];
+		expect(advance({ nodes, cancelling: false }).decisions).not.toContainEqual({ type: 'start', id: 'child' });
+	});
+
+	it('実行中は下流を待たせる', () => {
+		const nodes = [node({ id: 'child', state: 'RUNNING', subflow: true }), node({ id: 'after', state: 'PENDING', after: ['child'] })];
+		expect(advance({ nodes, cancelling: false }).decisions).toEqual([]);
+	});
+
+	it('子が失敗すると下流を打ち切る', () => {
+		const nodes = [node({ id: 'child', state: 'FAILED', subflow: true }), node({ id: 'after', state: 'PENDING', after: ['child'] })];
+		expect(advance({ nodes, cancelling: false }).decisions).toEqual([{ type: 'skip', id: 'after' }]);
+	});
+
+	it('取り消し中は実行中の子も止める', () => {
+		// ジョブと違い子のrunは実行中でも取り消せる
+		const nodes = [node({ id: 'child', state: 'RUNNING', subflow: true })];
+		expect(advance({ nodes, cancelling: true }).decisions).toEqual([{ type: 'cancel', id: 'child' }]);
+	});
+
+	it('取り消し中でも終端に達した子には何もしない', () => {
+		const nodes = [node({ id: 'child', state: 'COMPLETED', subflow: true })];
+		expect(advance({ nodes, cancelling: true }).decisions).toEqual([]);
 	});
 });

--- a/packages/tsumugi/test/unit/testing-harness.test.ts
+++ b/packages/tsumugi/test/unit/testing-harness.test.ts
@@ -10,7 +10,7 @@ class Greet extends Performer<{ name: string }, string, never, unknown> {
 
 class Boom extends Performer<unknown, void, never, unknown> {
 	perform(): void {
-		throw new Error('意図的な失敗');
+		throw new Error('intentional failure');
 	}
 }
 

--- a/packages/tsumugi/test/workers/consumer-errors.test.ts
+++ b/packages/tsumugi/test/workers/consumer-errors.test.ts
@@ -37,7 +37,7 @@ function message(body: unknown): FakeMessage {
 		ack: vi.fn(),
 		// consumerはretryを呼ばない, 呼べばQueuesのリトライに乗る(ADR-0004)
 		retry: vi.fn(() => {
-			throw new Error('retryは呼ばれてはならない');
+			throw new Error('retry must not be called');
 		}),
 	};
 }
@@ -86,7 +86,7 @@ describe('壊れたメッセージ(ADR-0004)', () => {
 describe('reportの失敗(ADR-0004)', () => {
 	it('reportがthrowしてもackは行われQueuesのリトライに乗らない', async () => {
 		const report = vi.fn(async () => {
-			throw new Error('DO到達不能');
+			throw new Error('DO unreachable');
 		});
 		const failingEnv = {
 			JOB_SHARD: {

--- a/packages/tsumugi/test/workers/mail-service.mjs
+++ b/packages/tsumugi/test/workers/mail-service.mjs
@@ -5,7 +5,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 export class SendMail extends WorkerEntrypoint {
 	async perform(payload, ctx) {
 		// RPC境界を越える例外の伝播を見るための口
-		if (payload?.fail) throw new Error('意図的な失敗');
+		if (payload?.fail) throw new Error('intentional failure');
 		return { to: payload?.to ?? null, jobId: ctx?.jobId ?? null, keys: Object.keys(ctx ?? {}) };
 	}
 }

--- a/packages/tsumugi/test/workers/metrics.test.ts
+++ b/packages/tsumugi/test/workers/metrics.test.ts
@@ -135,7 +135,7 @@ describe('tickからの書き出し', () => {
 		// writeDataPointが例外を投げる状況, メトリクスは省略可能なのでtickを止めてはいけない
 		const boom = {
 			writeDataPoint: () => {
-				throw new Error('AE不調');
+				throw new Error('AE is down');
 			},
 		} as unknown as AnalyticsEngineDataset;
 		const stub = shard('MET3#0');

--- a/packages/tsumugi/test/workers/projection.test.ts
+++ b/packages/tsumugi/test/workers/projection.test.ts
@@ -75,7 +75,7 @@ describe('D1への投影(ADR-0008)', () => {
 		const brokenDb = {
 			prepare: () => ({ bind: () => ({}) }),
 			batch: async () => {
-				throw new Error('D1が落ちている');
+				throw new Error('D1 is down');
 			},
 		};
 		await install('PROJ4#0', T0, brokenDb);

--- a/packages/tsumugi/test/workers/reliability.test.ts
+++ b/packages/tsumugi/test/workers/reliability.test.ts
@@ -12,7 +12,7 @@ let aborted = false;
 
 class Boom extends Performer<unknown, void, {}, ConsumerEnv> {
 	async perform(): Promise<void> {
-		throw new Error('意図的な失敗');
+		throw new Error('intentional failure');
 	}
 }
 
@@ -51,7 +51,7 @@ function makeBatch(bodies: DispatchMessage[]) {
 		attempts: 1,
 		ack: () => {},
 		retry: () => {
-			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+			throw new Error('consumer must not call retry (ADR-0004)');
 		},
 	}));
 	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;

--- a/packages/tsumugi/test/workers/remote-performer.test.ts
+++ b/packages/tsumugi/test/workers/remote-performer.test.ts
@@ -29,7 +29,7 @@ function makeBatch(bodies: DispatchMessage[]) {
 		attempts: 1,
 		ack: () => {},
 		retry: () => {
-			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+			throw new Error('consumer must not call retry (ADR-0004)');
 		},
 	}));
 	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;

--- a/packages/tsumugi/test/workers/run-slice.test.ts
+++ b/packages/tsumugi/test/workers/run-slice.test.ts
@@ -75,7 +75,7 @@ function makeBatch(bodies: DispatchMessage[]) {
 		attempts: 1,
 		ack: () => {},
 		retry: () => {
-			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+			throw new Error('consumer must not call retry (ADR-0004)');
 		},
 	}));
 	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;
@@ -130,7 +130,7 @@ async function settleRun(runId: string, rounds = 8): Promise<void> {
 		previous = current;
 		await runDurableObjectAlarm(runStub(runId));
 	}
-	throw new Error(`${rounds}回のtickでノードの状態が収束しない`);
+	throw new Error(`node states did not settle within ${rounds} ticks`);
 }
 
 const stateOf = (runId: string) =>
@@ -201,8 +201,8 @@ describe('縦串: runの開始から完了まで', () => {
 		sent.length = 0;
 		const jobId = await jobIdOf(runId, 'list');
 		// 通知はジョブIDで宛先を照合するので, 確定していなければ検査自体が成り立たない
-		if (jobId === null) throw new Error('先頭ノードにジョブIDが入っていない');
-		await stub.notify([{ nodeId: 'list', jobId, state: 'FAILED', result: null, error: '意図的な失敗' }]);
+		if (jobId === null) throw new Error('the first node has no job id');
+		await stub.notify([{ nodeId: 'list', jobId, state: 'FAILED', result: null, error: 'intentional failure' }]);
 		await settleRun(runId);
 
 		expect(Object.fromEntries(await nodesOf(runId))).toEqual({ list: 'FAILED', greet: 'SKIPPED', report: 'SKIPPED' });

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -15,7 +15,7 @@ function captureQueue() {
 			sendBatch: async (batch: Iterable<{ body: DispatchMessage }>) => {
 				const items = [...batch];
 				// プロデューサ側の100件上限, 超えると本番のsendBatchも失敗する
-				if (items.length > 100) throw new Error(`sendBatch上限100件を超過: ${items.length}`);
+				if (items.length > 100) throw new Error(`sendBatch exceeded the limit of 100: ${items.length}`);
 				batches.push(items.length);
 				for (const m of items) sent.push(m.body);
 			},

--- a/packages/tsumugi/test/workers/subflow.test.ts
+++ b/packages/tsumugi/test/workers/subflow.test.ts
@@ -50,7 +50,7 @@ function makeBatch(bodies: DispatchMessage[]) {
 		attempts: 1,
 		ack: () => {},
 		retry: () => {
-			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+			throw new Error('consumer must not call retry (ADR-0004)');
 		},
 	}));
 	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;
@@ -109,8 +109,8 @@ describe('subflowの縦串', () => {
 		await settle([parent, child], registry, 3);
 		sent.length = 0;
 		const jobId = (await nodeOf(child, 'list'))?.job_id;
-		if (!jobId) throw new Error('子の先頭ノードにジョブIDが入っていない');
-		await runStub(child).notify([{ nodeId: 'list', jobId, state: 'FAILED', result: null, error: '意図的な失敗' }]);
+		if (!jobId) throw new Error('the first node of the child run has no job id');
+		await runStub(child).notify([{ nodeId: 'list', jobId, state: 'FAILED', result: null, error: 'intentional failure' }]);
 		await settle([parent, child], registry);
 
 		expect(await stateOf(child)).toBe('FAILED');
@@ -141,7 +141,7 @@ describe('subflowの縦串', () => {
 			runInDurableObject(runStub('GREETINGS:too-deep'), (instance) =>
 				(instance as any).start({ flow: 'GREETINGS', input: { prefix: 'x' }, depth: 4 }),
 			),
-		).rejects.toThrow('subflowの入れ子が上限を超えた');
+		).rejects.toThrow('subflow nesting exceeded the limit');
 	});
 
 	it('子のrunが親を覚えている', async () => {

--- a/packages/tsumugi/test/workers/subflow.test.ts
+++ b/packages/tsumugi/test/workers/subflow.test.ts
@@ -1,0 +1,155 @@
+import { env, runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import { Performer } from '../../src/core/api.js';
+import type { DispatchMessage } from '../../src/do/job-shard.js';
+import type { TsumugiRunInstance } from '../../src/do/run.js';
+import { handleBatch, type ConsumerEnv } from '../../src/queue/consumer.js';
+
+/**
+ * 縦串: 親のrunが子のrunを起動して待つ
+ *
+ * flowの定義はexamples/basicが持つ(PIPELINEがGREETINGSを起動する)
+ */
+
+class ListNames extends Performer<{ prefix: string }, { names: string[] }, {}, ConsumerEnv> {
+	async perform(payload: { prefix: string }) {
+		return { names: [`${payload.prefix}-1`, `${payload.prefix}-2`] };
+	}
+}
+
+class Greet extends Performer<{ name: string }, { greeted: string }, {}, ConsumerEnv> {
+	async perform(payload: { name: string }) {
+		return { greeted: payload.name };
+	}
+}
+
+class Report extends Performer<{ total: number; failed: number }, void, {}, ConsumerEnv> {
+	async perform(): Promise<void> {}
+}
+
+const BINDINGS = ['LIST', 'GREET', 'REPORT'] as const;
+const consumerEnv: ConsumerEnv = env;
+
+const shard = (binding: string) => env.JOB_SHARD.get(env.JOB_SHARD.idFromName(`${binding}#0`));
+const runNamespace = env.RUN as unknown as DurableObjectNamespace<TsumugiRunInstance>;
+const runStub = (runId: string) => runNamespace.get(runNamespace.idFromName(runId));
+
+const sent: DispatchMessage[] = [];
+const queue = {
+	send: async (body: DispatchMessage) => void sent.push(body),
+	sendBatch: async (batch: Iterable<{ body: DispatchMessage }>) => {
+		for (const m of batch) sent.push(m.body);
+	},
+};
+
+function makeBatch(bodies: DispatchMessage[]) {
+	const messages = bodies.map((body, i) => ({
+		id: String(i),
+		timestamp: new Date(0),
+		body,
+		attempts: 1,
+		ack: () => {},
+		retry: () => {
+			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+		},
+	}));
+	return { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage>;
+}
+
+/** 親と子のRun DOとJob DOを交互に発火させ, 進みが止まるまで回す */
+async function settle(runIds: string[], performers: Record<string, unknown>, rounds = 16): Promise<void> {
+	for (let i = 0; i < rounds; i++) {
+		for (const binding of BINDINGS) {
+			await runInDurableObject(shard(binding), (instance) => {
+				(instance as any).env.TSUMUGI_QUEUE = queue;
+			});
+			await runDurableObjectAlarm(shard(binding));
+		}
+		if (sent.length > 0) {
+			const batch = makeBatch([...sent]);
+			sent.length = 0;
+			await handleBatch(batch, consumerEnv, performers as never);
+		}
+		for (const runId of runIds) await runDurableObjectAlarm(runStub(runId));
+	}
+}
+
+const stateOf = (runId: string) => runInDurableObject(runStub(runId), (instance) => (instance as any).repo.findRun()?.state as string);
+const nodeOf = (runId: string, nodeId: string) => runInDurableObject(runStub(runId), (instance) => (instance as any).repo.findNode(nodeId));
+
+describe('subflowの縦串', () => {
+	const registry = { LIST: ListNames, GREET: Greet, REPORT: Report };
+
+	it('子のrunを起動し, その終端を待って後段へ進む', async () => {
+		const parent = 'PIPELINE:sub-ok';
+		const child = 'GREETINGS:sub-ok-greetings';
+		await runStub(parent).start({ flow: 'PIPELINE', input: { prefix: 'hello' } });
+		await settle([parent, child], registry);
+
+		expect(await stateOf(child)).toBe('COMPLETED');
+		expect((await nodeOf(parent, 'greetings'))?.state).toBe('COMPLETED');
+		// 子の終端を待ってから後段が動く
+		expect((await nodeOf(parent, 'summary'))?.state).toBe('COMPLETED');
+		expect(await stateOf(parent)).toBe('COMPLETED');
+	});
+
+	it('子のrunIdが親のrunIdとノードIDから決まる', async () => {
+		const parent = 'PIPELINE:sub-id';
+		await runStub(parent).start({ flow: 'PIPELINE', input: { prefix: 'x' } });
+		await settle([parent, 'GREETINGS:sub-id-greetings'], registry, 2);
+
+		expect((await nodeOf(parent, 'greetings'))?.child_run_id).toBe('GREETINGS:sub-id-greetings');
+	});
+
+	it('子が失敗すると親のノードも失敗し下流を打ち切る', async () => {
+		const parent = 'PIPELINE:sub-fail';
+		const child = 'GREETINGS:sub-fail-greetings';
+		await runStub(parent).start({ flow: 'PIPELINE', input: { prefix: 'x' } });
+		// 子の先頭ノードを投入まで進めてから, 失敗の通知だけを手で届ける
+		await settle([parent, child], registry, 3);
+		sent.length = 0;
+		const jobId = (await nodeOf(child, 'list'))?.job_id;
+		if (!jobId) throw new Error('子の先頭ノードにジョブIDが入っていない');
+		await runStub(child).notify([{ nodeId: 'list', jobId, state: 'FAILED', result: null, error: '意図的な失敗' }]);
+		await settle([parent, child], registry);
+
+		expect(await stateOf(child)).toBe('FAILED');
+		expect((await nodeOf(parent, 'greetings'))?.state).toBe('FAILED');
+		expect((await nodeOf(parent, 'summary'))?.state).toBe('SKIPPED');
+		expect(await stateOf(parent)).toBe('FAILED');
+	});
+
+	it('親を取り消すと子も取り消される', async () => {
+		const parent = 'PIPELINE:sub-cancel';
+		const child = 'GREETINGS:sub-cancel-greetings';
+		await runStub(parent).start({ flow: 'PIPELINE', input: { prefix: 'x' } });
+		// 子が動き出すところまで進めてから取り消す
+		await settle([parent, child], registry, 2);
+		expect(await stateOf(child)).toBe('RUNNING');
+
+		await runStub(parent).cancel();
+		await settle([parent, child], registry);
+
+		expect(await stateOf(child)).toBe('CANCELLED');
+		expect(await stateOf(parent)).toBe('CANCELLED');
+	});
+
+	it('入れ子の上限を超える起動を弾く', async () => {
+		// 既定は3, 深さの判定は起動された側が行う
+		await expect(runStub('GREETINGS:too-deep').start({ flow: 'GREETINGS', input: { prefix: 'x' }, depth: 4 })).rejects.toThrow(
+			'subflowの入れ子が上限を超えた',
+		);
+	});
+
+	it('子のrunが親を覚えている', async () => {
+		const parent = 'PIPELINE:sub-parent';
+		const child = 'GREETINGS:sub-parent-greetings';
+		await runStub(parent).start({ flow: 'PIPELINE', input: { prefix: 'x' } });
+		await settle([parent, child], registry, 2);
+
+		const row = await runInDurableObject(runStub(child), (instance) => (instance as any).repo.findRun());
+		expect(row.parent_run_id).toBe(parent);
+		expect(row.parent_node_id).toBe('greetings');
+		expect(row.depth).toBe(1);
+	});
+});

--- a/packages/tsumugi/test/workers/subflow.test.ts
+++ b/packages/tsumugi/test/workers/subflow.test.ts
@@ -136,9 +136,12 @@ describe('subflowの縦串', () => {
 
 	it('入れ子の上限を超える起動を弾く', async () => {
 		// 既定は3, 深さの判定は起動された側が行う
-		await expect(runStub('GREETINGS:too-deep').start({ flow: 'GREETINGS', input: { prefix: 'x' }, depth: 4 })).rejects.toThrow(
-			'subflowの入れ子が上限を超えた',
-		);
+		// RPC越しの例外はvitest-pool-workersが未処理rejectionとして報告するためDO内で実行
+		await expect(
+			runInDurableObject(runStub('GREETINGS:too-deep'), (instance) =>
+				(instance as any).start({ flow: 'GREETINGS', input: { prefix: 'x' }, depth: 4 }),
+			),
+		).rejects.toThrow('subflowの入れ子が上限を超えた');
 	});
 
 	it('子のrunが親を覚えている', async () => {

--- a/packages/tsumugi/test/workers/vertical-slice.test.ts
+++ b/packages/tsumugi/test/workers/vertical-slice.test.ts
@@ -18,7 +18,7 @@ class Hello extends Performer<{ name: string }, void, {}, ConsumerEnv> {
 
 class Boom extends Performer<unknown, void, {}, ConsumerEnv> {
 	async perform(): Promise<void> {
-		throw new Error('意図的な失敗');
+		throw new Error('intentional failure');
 	}
 }
 
@@ -58,7 +58,7 @@ function makeBatch(bodies: DispatchMessage[]) {
 			acked.push(String(i));
 		},
 		retry: () => {
-			throw new Error('consumerはretryを呼んではならない(ADR-0004)');
+			throw new Error('consumer must not call retry (ADR-0004)');
 		},
 	}));
 	return { acked, batch: { queue: 'test', messages, ackAll: () => {}, retryAll: () => {} } as unknown as MessageBatch<DispatchMessage> };

--- a/site/guide/flow.md
+++ b/site/guide/flow.md
@@ -91,6 +91,34 @@ class Crawl extends Performer<{ url: string }, void, {}, Env> {
 `perform`が失敗した場合、その試行で要求した子ノードは作成されません。再実行時に改めて要求してください
 service binding越しのリモートperformerには`spawn`が渡されません
 
+## 別のFlowの起動
+
+`f.subflow`は、別のFlowをRunとして起動し、その終端を待ちます
+
+```ts
+const REPORTING = flow<{ ids: string[] }>((f) => {
+  // ...
+});
+
+const PIPELINE = flow<{ prefix: string }>((f) => {
+  const list = f.node('list', 'LIST', { input: (i) => ({ prefix: i.prefix }) });
+  const reported = f.subflow('report', REPORTING, { input: (_i, d) => ({ ids: d.list.ids }) });
+  f.node('notify', 'NOTIFY', { after: { reported }, input: () => ({}) });
+});
+```
+
+第2引数にはFlowの定義そのものを渡します。`input`の型は渡したFlowの型引数から決まります
+起動先は`flows`に登録されている必要があります。登録されていない場合は起動時にエラーになります
+
+子のrunIdは`<子のFlow名>:<親のrunIdのローカル部>-<ノードID>`です
+
+子の状態がそのままノードの状態になります。`COMPLETED`、`FAILED`、`CANCELLED`のいずれかです
+子の戻り値は受け取りません。結果が必要な場合は、performerからR2やD1へ書き込んでください
+
+親を取り消すと子も取り消されます
+
+入れ子は既定で3段までです。`defineTsumugi`の`runs.maxDepth`で変更可能です
+
 ## 待ち合わせ
 
 ノードは、自身と子孫のすべてが終わった時点で完了として扱われます
@@ -115,6 +143,7 @@ service binding越しのリモートperformerには`spawn`が渡されません
 - ノードは`uniqueKey`を受け付けません。`uniqueKey`を必須と宣言したperformerをノードに指定すると型エラーになります
 - ノードの戻り値が8,192文字を超えた場合、そのノードは失敗になります。大きい結果はR2等へ書き込み、参照を戻り値としてください
 - 1つのRunに含められるノード数は既定で10,000件です。`defineTsumugi`の`runs.maxNodes`で変更可能です
+- subflowの入れ子は既定で3段までです。`defineTsumugi`の`runs.maxDepth`で変更可能です
 
 ## 設定
 

--- a/site/guide/performer.md
+++ b/site/guide/performer.md
@@ -62,7 +62,7 @@ at-least-onceでは同じジョブが2回実行される場合があるため、
 class ChargeCard extends Performer<{ customerId: string; amountJpy: number }, void, { concurrencyKey: true }, Env> {
   async perform(payload: { customerId: string; amountJpy: number }): Promise<void> {
     const res = await this.env.PAYMENT.charge(payload);
-    if (!res.ok) throw new Error(`決済に失敗: ${res.status}`);
+    if (!res.ok) throw new Error(`payment failed: ${res.status}`);
   }
 }
 ```

--- a/site/reference/rest-api.md
+++ b/site/reference/rest-api.md
@@ -68,7 +68,7 @@ HTML自体はデータを含まないため未認証でも返します。SPA側�
         "state": "FAILED",
         "started_at": 1753000010000,
         "finished_at": 1753000012000,
-        "error": "決済に失敗: 502"
+        "error": "payment failed: 502"
       }
     ]
   }


### PR DESCRIPTION
related: #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フローから別のサブフローを起動し、完了・失敗・キャンセル状態を親フローへ反映できるようになりました。
  * サブフローの実行階層と親子関係を詳細画面で確認できます。
  * 実行対象の子Runを起動するボタンを追加しました。
  * サブフローの入れ子深度上限を設定できるようになりました。

* **ドキュメント**
  * サブフローの利用方法、制約、状態連携について説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->