### PR TITLE
feat: 起動時に不足したbindingを検出する

### DIFF
--- a/docs/decision/0036-startup-validation-vs-cli.md
+++ b/docs/decision/0036-startup-validation-vs-cli.md
@@ -1,0 +1,53 @@
+# ADR-0036: 起動時検証は検出に徹しCLIが生成を担う
+
+## 状況
+
+ADR-0017は`init`と`add-performer`を持つ専用CLIを将来作る方針とし,v0.1では起動時の設定検証で代替するとした
+その起動時検証の範囲を定めないままなので,CLIとの分担が決まらず双方とも着手できていない
+
+現状で検出できるのはマイグレーションの適用漏れ(`projection/migrations.ts`)と,run開始時のRUN binding未設定の2つのみ
+それ以外のbindingの記述漏れは,ジョブを投入した後の実行時エラーとして現れる
+
+## 決定
+
+CLIは今作る,ADR-0017の後回しは取り消す
+起動時検証とCLIの分担は「検証は検出,CLIは生成」とする
+
+### 起動時検証が担う範囲
+
+次の3つに限る
+
+- 必須bindingの存在確認, 対象は`JOB_SHARD` / `TSUMUGI_DB` / `TSUMUGI_QUEUE`, flowを使う構成では`RUN`も含める
+- performerのservice bindingの整合確認, 指した名前が`env`に在り`perform`を持つか(ADR-0026)
+- 不足分について,wrangler設定へ貼り付けられる断片の出力
+
+`TSUMUGI_METRICS`は必須にしない
+未設定でもメトリクスが書かれないだけで,ジョブの実行は成立する
+
+マイグレーションの適用そのものは`wrangler d1 migrations apply`に委ね,検証は未適用の検知に留める
+検知は既存の`projection/migrations.ts`を再利用し,binding検証とは別の判定として並立させる
+
+### CLIが担う範囲
+
+- `tsumugi init` — D1とキューを作り,wrangler設定とWorkerの雛形を生成し,読み取りモデルのマイグレーションを適用する
+- `tsumugi add-performer <NAME>` — performerのファイルを生成し,`services`へ追記する断片を出力する
+
+D1の作成とマイグレーションの適用はCLIが`wrangler`を実行して行う
+`wrangler d1 create`が出力するdatabase_idは生成した設定へそのまま書き込む,手で貼り直させると転記の誤りが入る可能性があるため
+
+既存のファイルは書き換えない
+`wrangler.jsonc`が既に在る場合は追記すべき断片を出力し,判断を利用者に残す
+
+## 帰結
+
+設定漏れはジョブの投入前に判明し,不足したbindingの断片がそのまま貼り付けられる
+Workersに起動フックが無いため「初回の呼び出しを起動とみなす」形になり,検証は最初のリクエストまで走らない
+検証できるのは`env`に見える範囲に限られ,wrangler設定そのものとの突き合わせはできない
+
+CLIが生成する断片と起動時検証が出す断片は同じ実装から作る, 2箇所で書くと片方だけが古くなる
+
+## 参照
+
+- ADR-0013 認証をfail-closedにする, 設定漏れを動作しない状態として現す方針をbinding検証にも適用する
+- ADR-0017 専用CLIを作る方針だがv0.1では後回しにする, 本ADRが後回しを取り消し範囲を確定する
+- ADR-0026 performerをservice binding越しに置けるようにする, performerの整合確認はこの構成が前提

--- a/docs/decision/README.md
+++ b/docs/decision/README.md
@@ -38,3 +38,4 @@
 - [ADR-0033](0033-no-unique-key-in-node.md) — runのノードでuniqueKeyを受け付けない
 - [ADR-0034](0034-resume-from-failed-node.md) — 失敗したrunは失敗したノードから再開する
 - [ADR-0035](0035-bounded-run-data.md) — runを跨ぐデータと規模に上限を設ける
+- [ADR-0036](0036-startup-validation-vs-cli.md) — 起動時検証は検出に徹しCLIが生成を担う

--- a/packages/tsumugi/src/config/fragment.ts
+++ b/packages/tsumugi/src/config/fragment.ts
@@ -1,0 +1,107 @@
+import type { BindingKind, MissingBinding } from './validate.js';
+
+/**
+ * 不足したbindingからwrangler設定の断片を作る(ADR-0036)
+ *
+ * `examples/basic/wrangler.jsonc`の構成をそのまま雛形にする
+ * 値は利用者が埋める箇所だけを空にし,残りは貼ればそのまま通る形にする
+ */
+
+/** D1のマイグレーションの既定の置き場所, パッケージが持つSQLを指す */
+export const DEFAULT_MIGRATIONS_DIR = './node_modules/tsumugi/migrations';
+
+/** Durable Objectのmigrationsのtagは順に増やす, 既存と衝突しない番号を利用者が振り直す */
+const DO_MIGRATION_TAG = 'vN';
+
+const jsonc = (value: unknown): string => JSON.stringify(value, null, 2);
+
+const durableObjects = (entries: MissingBinding[]): string[] => {
+	if (entries.length === 0) return [];
+	const bindings = entries.map((entry) => ({ name: entry.name, class_name: entry.className ?? entry.name }));
+	return [
+		`"durable_objects": { "bindings": ${jsonc(bindings)} }`,
+		`// tagは既存と衝突しない番号へ振り直す\n"migrations": ${jsonc([{ tag: DO_MIGRATION_TAG, new_sqlite_classes: bindings.map((b) => b.class_name) }])}`,
+	];
+};
+
+const d1 = (entries: MissingBinding[]): string[] =>
+	entries.map(
+		(entry) =>
+			`// database_idは\`wrangler d1 create <name>\`の出力を貼る\n"d1_databases": ${jsonc([
+				{
+					binding: entry.name,
+					database_name: '<database>',
+					database_id: '<id>',
+					migrations_dir: DEFAULT_MIGRATIONS_DIR,
+				},
+			])}`,
+	);
+
+const queues = (entries: MissingBinding[]): string[] =>
+	entries.map(
+		(entry) =>
+			`"queues": ${jsonc({
+				producers: [{ binding: entry.name, queue: '<queue>' }],
+				consumers: [{ queue: '<queue>', max_batch_size: 10, max_retries: 5 }],
+			})}`,
+	);
+
+const analytics = (entries: MissingBinding[]): string[] =>
+	entries.map((entry) => `"analytics_engine_datasets": ${jsonc([{ binding: entry.name, dataset: '<dataset>' }])}`);
+
+const services = (entries: MissingBinding[]): string[] => {
+	if (entries.length === 0) return [];
+	const list = entries.map((entry) => ({ binding: entry.name, service: '<worker>', entrypoint: '<PerformerClass>' }));
+	return [`// serviceとentrypointは相手のWorkerの名前とクラス名に合わせる\n"services": ${jsonc(list)}`];
+};
+
+const BUILDERS: Record<BindingKind, (entries: MissingBinding[]) => string[]> = {
+	'durable-object': durableObjects,
+	d1,
+	queue: queues,
+	analytics,
+	service: services,
+};
+
+const ORDER: readonly BindingKind[] = ['durable-object', 'd1', 'queue', 'analytics', 'service'];
+
+/** 貼り付けられるJSONCの断片, 種別ごとにまとめる */
+export function configFragment(missing: readonly MissingBinding[]): string {
+	const blocks = ORDER.flatMap((kind) => BUILDERS[kind](missing.filter((entry) => entry.kind === kind)));
+	return blocks.join(',\n');
+}
+
+const LABELS: Record<BindingKind, string> = {
+	'durable-object': 'Durable Object',
+	d1: 'D1',
+	queue: 'Queues',
+	analytics: 'Analytics Engine',
+	service: 'service binding',
+};
+
+/**
+ * 読んだ人がそのまま直せる説明を作る
+ * `migrations.ts`の`migrationErrorMessage`に倣い,断片と次に実行するコマンドまで含める
+ */
+export function configErrorMessage(missing: readonly MissingBinding[]): string {
+	const lines = missing.map((entry) => {
+		const detail = entry.reason === 'invalid' ? 'performerを持たない' : '未設定';
+		return `✗ ${entry.name} (${LABELS[entry.kind]}) が${detail}`;
+	});
+
+	const next = ['wrangler.jsonc へ次の断片を追記する'];
+	if (missing.some((entry) => entry.kind === 'd1')) {
+		next.push('wrangler d1 create <database> でデータベースを作る');
+		next.push('wrangler d1 migrations apply <database> --remote で読み取りモデルを用意する');
+	}
+	if (missing.some((entry) => entry.kind === 'queue')) next.push('wrangler queues create <queue> でキューを作る');
+
+	return [
+		'tsumugi: wranglerの設定が足りない',
+		...lines,
+		'',
+		...next.map((step, index) => `${index + 1}. ${step}`),
+		'',
+		configFragment(missing),
+	].join('\n');
+}

--- a/packages/tsumugi/src/config/validate.ts
+++ b/packages/tsumugi/src/config/validate.ts
@@ -1,0 +1,92 @@
+import { isRemoteRef } from '../core/api.js';
+import type { PerformerRegistry } from '../queue/consumer.js';
+import type { Flows } from '../core/flow.js';
+
+/**
+ * 起動時の設定検証(ADR-0036)
+ *
+ * bindingの記述漏れはジョブを投入した後の実行時エラーとして現れる
+ * 最初の呼び出しで`env`を見て,不足を貼り付けられる断片とともに返す
+ * wrangler設定そのものは読めないので,判定は`env`に見える範囲に限る
+ */
+
+/** 不足したbindingの種別, 生成する設定断片の形が種別ごとに違う */
+export type BindingKind = 'durable-object' | 'd1' | 'queue' | 'analytics' | 'service';
+
+export type MissingBinding = {
+	kind: BindingKind;
+	/** wrangler設定に書くbinding名 */
+	name: string;
+	/** Durable Objectのクラス名, 種別がdurable-objectの場合のみ */
+	className?: string;
+	/** 不足の理由, 存在しないのか形が違うのか */
+	reason: 'absent' | 'invalid';
+};
+
+/**
+ * 検証結果
+ * `migrations.ts`の`MigrationStatus`に倣い,判別可能なユニオンで返す
+ */
+export type ConfigStatus = { ok: true } | { ok: false; missing: MissingBinding[] };
+
+export type ValidateInput = {
+	performers: PerformerRegistry<any>;
+	flows?: Flows;
+};
+
+/**
+ * 常に要るbinding, flowを使う構成では`RUN`が加わる
+ * `TSUMUGI_METRICS`は含めない, 未設定でもメトリクスが書かれないだけで実行は成立する(ADR-0036)
+ */
+const REQUIRED: readonly { name: string; kind: BindingKind; className?: string }[] = [
+	{ name: 'JOB_SHARD', kind: 'durable-object', className: 'TsumugiJobShard' },
+	{ name: 'TSUMUGI_DB', kind: 'd1' },
+	{ name: 'TSUMUGI_QUEUE', kind: 'queue' },
+];
+
+const RUN_BINDING = { name: 'RUN', kind: 'durable-object' as const, className: 'TsumugiRun' };
+
+const absent = (value: unknown): boolean => value === undefined || value === null;
+
+/**
+ * `env`と`defineTsumugi`の設定を突き合わせる
+ * リモートperformerの検査はconsumerと同じ判定を起動時へ前倒しする(ADR-0026)
+ */
+export function validateConfig(env: Record<string, unknown>, config: ValidateInput): ConfigStatus {
+	const missing: MissingBinding[] = [];
+
+	const required = [...REQUIRED, ...(config.flows && Object.keys(config.flows).length > 0 ? [RUN_BINDING] : [])];
+	for (const entry of required) {
+		if (absent(env[entry.name])) {
+			missing.push({ kind: entry.kind, name: entry.name, reason: 'absent', ...(entry.className ? { className: entry.className } : {}) });
+		}
+	}
+
+	for (const entry of Object.values(config.performers)) {
+		if (!isRemoteRef(entry)) continue;
+		const service = env[entry.binding] as { perform?: unknown } | undefined;
+		if (absent(service)) missing.push({ kind: 'service', name: entry.binding, reason: 'absent' });
+		// 名前は在るが相手がperformerでない場合, 実行時まで気付けないので同じ扱いにする
+		else if (typeof service?.perform !== 'function') missing.push({ kind: 'service', name: entry.binding, reason: 'invalid' });
+	}
+
+	return missing.length === 0 ? { ok: true } : { ok: false, missing };
+}
+
+/**
+ * 検証結果をisolate単位で使い回す(ADR-0036)
+ *
+ * Workersに起動フックは無いので,最初の呼び出しを起動とみなす
+ * 成功は永続でキャッシュする, `env`は同じisolateの間は変わらない
+ * 不足はキャッシュしない, 設定を足した後に再デプロイせず自力で復帰させる
+ */
+export function cachedValidate(config: ValidateInput): (env: Record<string, unknown>) => ConfigStatus {
+	let settled: ConfigStatus | undefined;
+
+	return (env) => {
+		if (settled?.ok) return settled;
+		const status = validateConfig(env, config);
+		if (status.ok) settled = status;
+		return status;
+	};
+}

--- a/packages/tsumugi/src/config/validate.ts
+++ b/packages/tsumugi/src/config/validate.ts
@@ -62,8 +62,11 @@ export function validateConfig(env: Record<string, unknown>, config: ValidateInp
 		}
 	}
 
+	// 同じbindingを複数のperformerが指しても報告は1件, 断片も重複させない
+	const checked = new Set<string>();
 	for (const entry of Object.values(config.performers)) {
-		if (!isRemoteRef(entry)) continue;
+		if (!isRemoteRef(entry) || checked.has(entry.binding)) continue;
+		checked.add(entry.binding);
 		const service = env[entry.binding] as { perform?: unknown } | undefined;
 		if (absent(service)) missing.push({ kind: 'service', name: entry.binding, reason: 'absent' });
 		// 名前は在るが相手がperformerでない場合, 実行時まで気付けないので同じ扱いにする

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -11,6 +11,8 @@ import type { AuthMiddleware } from './api/auth.js';
 import { createRest, type RestEnv } from './api/rest.js';
 import { sweepReadModel, type SweepOptions } from './projection/sweep.js';
 import type { Ui } from './ui/serve.js';
+import { cachedValidate } from './config/validate.js';
+import { configErrorMessage } from './config/fragment.js';
 
 export type { BindingConfig, ClientEnv };
 
@@ -113,14 +115,28 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 	// flow名はrunIdの一部になる, 起動時に弾かないと開始まで誤りに気付けない(ADR-0029)
 	for (const flow of Object.keys(flows)) assertValidFlow(flow);
 
+	// Workersに起動フックが無いので, 最初の呼び出しを起動とみなして検証する(ADR-0036)
+	const checkConfig = cachedValidate({ performers, flows });
+
+	/**
+	 * 設定漏れを不足の一覧付きで断る(ADR-0013)
+	 * 貼り付けられる断片まで含めた本文にする, 番号だけでは何を足せばよいか分からない
+	 */
+	const assertConfigured = (env: Env): void => {
+		const status = checkConfig(env as unknown as Record<string, unknown>);
+		if (!status.ok) throw new Error(configErrorMessage(status.missing));
+	};
+
 	/** 設定漏れは開始時にエラーにする, エラーにしないとノードが永久に実行されない(ADR-0013) */
 	const runFor = (env: Env, runId: string): DurableObjectStub<RunControl> => {
 		const namespace = env.RUN;
+		// RUNだけ個別に見る, 不足の一覧より宛先が無い事実を先に伝える方が短い
 		if (!namespace) throw new Error('RUN binding が未設定, wranglerにRun DOのbindingを足す必要がある');
 		return namespace.get(namespace.idFromName(runId));
 	};
 
 	const start = async (env: Env, flow: string, input: unknown, options?: { id?: string }): Promise<string> => {
+		assertConfigured(env);
 		if (!flows[flow]) throw new Error(`flowが未登録: ${flow}`);
 		const runId = formatRunId({ flow, localId: options?.id ?? createId() });
 		const result = await runFor(env, runId).start({ flow, input });
@@ -149,6 +165,12 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 		async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 			// 認証が設定されるまで何も提供しない, 設定漏れが動作しない状態として現れる(ADR-0013)
 			if (!rest) return new Response('not found', { status: 404 });
+
+			// bindingの不足はマイグレーションの適用漏れと同じく503で断る, どちらも構成の問題(ADR-0036)
+			const status = checkConfig(env as unknown as Record<string, unknown>);
+			if (!status.ok && new URL(request.url).pathname.startsWith('/api/')) {
+				return Response.json({ error: configErrorMessage(status.missing), missing: status.missing }, { status: 503 });
+			}
 			return rest.fetch(request, env, ctx);
 		},
 		async queue(batch: MessageBatch<DispatchMessage>, env: Env): Promise<void> {
@@ -175,10 +197,12 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 			return client.shardFor(env, binding, partitionKey) as DurableObjectStub<TsumugiJobShard>;
 		},
 		enqueue(env: Env, input: TypedEnqueueInput<PerformersOf<R>>): Promise<string> {
+			assertConfigured(env);
 			// TypedEnqueueInputは構造的にEnqueueInputの部分集合なのでそのまま渡せる
 			return client.enqueue(env, input as unknown as EnqueueInput);
 		},
 		enqueueMany(env: Env, inputs: readonly TypedEnqueueInput<PerformersOf<R>>[]): Promise<string[]> {
+			assertConfigured(env);
 			return client.enqueueMany(env, inputs as unknown as readonly EnqueueInput[]);
 		},
 		start,

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -184,13 +184,17 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 		jobs(env: Env): JobQueue<PerformersOf<R>> {
 			return {
 				// positional形をDOが受けるEnqueueInputへ変換する, 型はJobQueue<M>で縛る
-				enqueue: (binding: string, payload: unknown, options?: object) =>
-					client.enqueue(env, { binding, payload, ...options } as EnqueueInput),
-				enqueueMany: (items: readonly { binding: string; payload: unknown; options?: object }[]) =>
-					client.enqueueMany(
+				enqueue: (binding: string, payload: unknown, options?: object) => {
+					assertConfigured(env);
+					return client.enqueue(env, { binding, payload, ...options } as EnqueueInput);
+				},
+				enqueueMany: (items: readonly { binding: string; payload: unknown; options?: object }[]) => {
+					assertConfigured(env);
+					return client.enqueueMany(
 						env,
 						items.map((it) => ({ binding: it.binding, payload: it.payload, ...it.options }) as EnqueueInput),
-					),
+					);
+				},
 			} as JobQueue<PerformersOf<R>>;
 		},
 		shardFor(env: Env, binding: string, partitionKey?: string): DurableObjectStub<TsumugiJobShard> {

--- a/packages/tsumugi/test/unit/config-validate.test.ts
+++ b/packages/tsumugi/test/unit/config-validate.test.ts
@@ -80,6 +80,14 @@ describe('リモートperformerの整合(ADR-0026)', () => {
 		expect(status.missing).toEqual([{ kind: 'service', name: 'MAIL_SERVICE', reason: 'invalid' }]);
 	});
 
+	it('同じbindingを指すperformerが複数でも1件にまとめる', () => {
+		// 重複するとエラー本文にも設定断片にも同じserviceが並ぶ
+		const env = complete();
+		delete (env as Record<string, unknown>).MAIL_SERVICE;
+		const shared = { A: remote('MAIL_SERVICE'), B: remote('MAIL_SERVICE') };
+		expect(names(validateConfig(env, { performers: shared }))).toEqual(['MAIL_SERVICE']);
+	});
+
 	it('揃っていれば通る', () => {
 		expect(validateConfig(complete(), { performers: withRemote })).toEqual({ ok: true });
 	});

--- a/packages/tsumugi/test/unit/config-validate.test.ts
+++ b/packages/tsumugi/test/unit/config-validate.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { Performer, remote } from '../../src/core/api.js';
+import { cachedValidate, validateConfig } from '../../src/config/validate.js';
+import { configErrorMessage, configFragment, DEFAULT_MIGRATIONS_DIR } from '../../src/config/fragment.js';
+
+class Noop extends Performer<unknown, void> {
+	async perform(): Promise<void> {}
+}
+
+/** 必須bindingが揃った`env`, 個々のテストで欠けさせる */
+const complete = () => ({
+	JOB_SHARD: {},
+	TSUMUGI_DB: {},
+	TSUMUGI_QUEUE: {},
+	TSUMUGI_METRICS: {},
+	RUN: {},
+	MAIL_SERVICE: { perform: () => {} },
+});
+
+const performers = { LOCAL: Noop };
+const withRemote = { LOCAL: Noop, MAIL: remote('MAIL_SERVICE') };
+const flows = { GREETINGS: { nodes: [] } };
+
+const names = (status: ReturnType<typeof validateConfig>) => (status.ok ? [] : status.missing.map((entry) => entry.name).sort());
+
+describe('必須bindingの検証', () => {
+	it('揃っていれば通る', () => {
+		expect(validateConfig(complete(), { performers })).toEqual({ ok: true });
+	});
+
+	it('欠けたbindingを種別付きで列挙する', () => {
+		const status = validateConfig({}, { performers });
+		expect(status.ok).toBe(false);
+		if (status.ok) return;
+		expect(status.missing).toEqual([
+			{ kind: 'durable-object', name: 'JOB_SHARD', reason: 'absent', className: 'TsumugiJobShard' },
+			{ kind: 'd1', name: 'TSUMUGI_DB', reason: 'absent' },
+			{ kind: 'queue', name: 'TSUMUGI_QUEUE', reason: 'absent' },
+		]);
+	});
+
+	it('TSUMUGI_METRICSは求めない', () => {
+		// 未設定でもメトリクスが書かれないだけで実行は成立する(ADR-0036)
+		const env = complete();
+		delete (env as Record<string, unknown>).TSUMUGI_METRICS;
+		expect(validateConfig(env, { performers })).toEqual({ ok: true });
+	});
+
+	it('flowを使わない構成ではRUNを求めない', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).RUN;
+		expect(validateConfig(env, { performers })).toEqual({ ok: true });
+	});
+
+	it('flowを使う構成ではRUNも求める', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).RUN;
+		expect(names(validateConfig(env, { performers, flows }))).toEqual(['RUN']);
+	});
+
+	it('flowが空なら求めない', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).RUN;
+		expect(validateConfig(env, { performers, flows: {} })).toEqual({ ok: true });
+	});
+});
+
+describe('リモートperformerの整合(ADR-0026)', () => {
+	it('service bindingが無ければ不足に載る', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).MAIL_SERVICE;
+		expect(names(validateConfig(env, { performers: withRemote }))).toEqual(['MAIL_SERVICE']);
+	});
+
+	it('名前は在るがperformerでない場合も弾く', () => {
+		// 実行時までずれに気付けないので, 起動時に同じ扱いにする
+		const status = validateConfig({ ...complete(), MAIL_SERVICE: {} }, { performers: withRemote });
+		expect(status.ok).toBe(false);
+		if (status.ok) return;
+		expect(status.missing).toEqual([{ kind: 'service', name: 'MAIL_SERVICE', reason: 'invalid' }]);
+	});
+
+	it('揃っていれば通る', () => {
+		expect(validateConfig(complete(), { performers: withRemote })).toEqual({ ok: true });
+	});
+});
+
+describe('検証結果のキャッシュ', () => {
+	it('成功は使い回す', () => {
+		const check = cachedValidate({ performers });
+		expect(check(complete())).toEqual({ ok: true });
+		// 2回目は`env`を空にしても再判定しない, 同じisolateでbindingは変わらない
+		expect(check({})).toEqual({ ok: true });
+	});
+
+	it('不足はキャッシュしない', () => {
+		// 設定を足した後に再デプロイせず自力で復帰させる
+		const check = cachedValidate({ performers });
+		expect(check({}).ok).toBe(false);
+		expect(check(complete())).toEqual({ ok: true });
+	});
+});
+
+describe('設定断片の生成', () => {
+	const fragmentOf = (env: Record<string, unknown>, input = { performers: withRemote, flows }) => {
+		const status = validateConfig(env, input);
+		return status.ok ? '' : configFragment(status.missing);
+	};
+
+	it('種別ごとのキーを出す', () => {
+		const fragment = fragmentOf({});
+		expect(fragment).toContain('"durable_objects"');
+		expect(fragment).toContain('"migrations"');
+		expect(fragment).toContain('"d1_databases"');
+		expect(fragment).toContain('"queues"');
+		expect(fragment).toContain('"services"');
+	});
+
+	it('Durable Objectはbindingとクラス名を対にする', () => {
+		const fragment = fragmentOf({});
+		expect(fragment).toContain('"class_name": "TsumugiJobShard"');
+		expect(fragment).toContain('"class_name": "TsumugiRun"');
+		expect(fragment).toContain('"new_sqlite_classes"');
+	});
+
+	it('D1のmigrations_dirはパッケージのSQLを指す', () => {
+		expect(fragmentOf({})).toContain(DEFAULT_MIGRATIONS_DIR);
+	});
+
+	it('Queuesはproducerとconsumerの両方を出す', () => {
+		const fragment = fragmentOf({});
+		expect(fragment).toContain('"producers"');
+		expect(fragment).toContain('"consumers"');
+	});
+
+	it('service bindingはリモートperformerの名前を反映する', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).MAIL_SERVICE;
+		expect(fragmentOf(env)).toContain('"binding": "MAIL_SERVICE"');
+	});
+
+	it('揃っている種別の断片は出さない', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).TSUMUGI_QUEUE;
+		const fragment = fragmentOf(env);
+		expect(fragment).toContain('"queues"');
+		expect(fragment).not.toContain('"d1_databases"');
+	});
+});
+
+describe('設定漏れの説明', () => {
+	it('不足の一覧と次に実行するコマンドを含む', () => {
+		const status = validateConfig({}, { performers });
+		if (status.ok) throw new Error('不足しているはず');
+		const message = configErrorMessage(status.missing);
+
+		expect(message).toContain('✗ TSUMUGI_DB (D1) が未設定');
+		expect(message).toContain('wrangler d1 create');
+		expect(message).toContain('wrangler d1 migrations apply');
+		expect(message).toContain('wrangler queues create');
+		expect(message).toContain('"d1_databases"');
+	});
+
+	it('関係の無いコマンドは出さない', () => {
+		const env = complete();
+		delete (env as Record<string, unknown>).TSUMUGI_QUEUE;
+		const status = validateConfig(env, { performers });
+		if (status.ok) throw new Error('不足しているはず');
+
+		const message = configErrorMessage(status.missing);
+		expect(message).toContain('wrangler queues create');
+		expect(message).not.toContain('wrangler d1 create');
+	});
+
+	it('performerを持たないservice bindingは理由を分ける', () => {
+		const status = validateConfig({ ...complete(), MAIL_SERVICE: {} }, { performers: withRemote });
+		if (status.ok) throw new Error('不足しているはず');
+		expect(configErrorMessage(status.missing)).toContain('performerを持たない');
+	});
+});


### PR DESCRIPTION
related: #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 起動時・ジョブ投入前に、必須バインディングやリモートサービス設定の不足を検出できるようになりました。
  * 不足している設定の説明と、Wrangler設定へ貼り付け可能な構成断片を表示します。
  * 設定不足時のAPIリクエストは、詳細なエラー情報を含む503応答を返します。

* **ドキュメント**
  * 起動時検証とCLIによる設定生成の役割分担に関するADRを追加しました。

* **テスト**
  * 設定検証、キャッシュ、構成断片生成、エラーメッセージのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->