### PR TITLE
feat: ジョブの詳細からrunへの導線を追加

### DIFF
--- a/packages/dashboard/src/App.vue
+++ b/packages/dashboard/src/App.vue
@@ -524,7 +524,15 @@ const columnClass = (key: keyof typeof COLUMN) => (visible.value[key] ? COLUMN[k
 			<Pagination v-if="isList" v-model:page="page" v-model:page-size="pageSize" :total="total" :unit="tab" />
 		</div>
 
-		<JobDetailModal :job-id="selected" @close="selected = null" @changed="load" />
+		<JobDetailModal
+			:job-id="selected"
+			@close="selected = null"
+			@changed="load"
+			@run="
+				selected = null;
+				selectedRun = $event;
+			"
+		/>
 		<NewJobModal
 			:open="creating"
 			:bindings="bindings"

--- a/packages/dashboard/src/components/JobDetailModal.vue
+++ b/packages/dashboard/src/components/JobDetailModal.vue
@@ -7,7 +7,7 @@ import { getJob, type Attempt, type Job } from '../api';
 import { useJobActions } from '../useJobActions';
 
 const props = defineProps<{ jobId: string | null }>();
-const emit = defineEmits<{ close: []; changed: [] }>();
+const emit = defineEmits<{ close: []; changed: []; run: [string] }>();
 
 const job = ref<Job | null>(null);
 const attempts = ref<Attempt[]>([]);
@@ -111,6 +111,19 @@ const pretty = (payload: string | undefined) => {
 								<dd class="font-mono text-xs break-all">{{ job.id }}</dd>
 								<dt class="text-muted-foreground">Binding</dt>
 								<dd>{{ job.binding }}</dd>
+								<template v-if="job.run_id">
+									<dt class="text-muted-foreground">Run</dt>
+									<dd>
+										<button
+											type="button"
+											class="border-none font-mono text-xs break-all underline underline-offset-2 hover:text-foreground"
+											@click="emit('run', job.run_id)"
+										>
+											{{ job.run_id }}
+										</button>
+										<span v-if="job.node_id" class="ml-1 text-xs text-muted-foreground">{{ job.node_id }}</span>
+									</dd>
+								</template>
 								<dt class="text-muted-foreground">Attempts</dt>
 								<dd class="tabular-nums">{{ job.attempts }} / {{ job.max_attempts }}</dd>
 								<!-- 報告するperformerでのみ埋まる -->

--- a/packages/spec/models.tsp
+++ b/packages/spec/models.tsp
@@ -66,6 +66,12 @@ model JobDetail {
 	@doc("JSON-encoded return value of perform. Present only on success.")
 	result: string | null;
 
+	@doc("Run that enqueued this job. Null for a job enqueued on its own.")
+	run_id: string | null;
+
+	@doc("Node that enqueued this job. Set together with run_id.")
+	node_id: string | null;
+
 	@doc("Newest attempt first")
 	attempts_log: AttemptRecord[];
 }

--- a/packages/tsumugi/src/api/rest.ts
+++ b/packages/tsumugi/src/api/rest.ts
@@ -644,6 +644,9 @@ export function createRest<Env extends RestEnv>(auth: AuthMiddleware, options: R
 			payload: found.payload,
 			// performの戻り値, 成功時のみ入り未完了はnull(#9), payloadと同じくJSON文字列のまま返す
 			result: found.result,
+			// 投入元のrunへ画面から辿れるようにする, 単発で投入したジョブはnull(ADR-0015)
+			run_id: found.runId,
+			node_id: found.nodeId,
 		};
 		// 履歴は詳細でだけ返す, 一覧に載せると1画面で数百KBになり得る(ADR-0028)
 		// `attempts`は試行回数の数値なので別名にする, 上書きすると画面の n/m が壊れる

--- a/packages/tsumugi/src/api/types.ts
+++ b/packages/tsumugi/src/api/types.ts
@@ -42,6 +42,10 @@ export type JobDetail = JobSummary & {
 	payload: string;
 	/** performの戻り値, 成功時のみ入る(#9) */
 	result: string | null;
+	/** 投入元のrun, 単発で投入したジョブはnull(ADR-0015) */
+	run_id: string | null;
+	/** 投入元のノード, runと対で入る */
+	node_id: string | null;
 	/** 新しい試行から順に入る */
 	attempts_log: AttemptRecord[];
 };

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -156,16 +156,39 @@ describe('REST API', () => {
 			'guarantee',
 			'id',
 			'max_attempts',
+			'node_id',
 			'payload',
 			'priority',
 			'progress',
 			'result',
 			'retryable',
 			'run_after',
+			'run_id',
 			'state',
 			'unique_key',
 			'updated_at',
 		]);
+	});
+
+	it('runから投入したジョブは詳細で宛先を返す(ADR-0015)', async () => {
+		// 画面はここからrunの詳細へ辿る, 単発で投入したジョブはnullのまま
+		const runId = 'REST:link';
+		await env.TSUMUGI_DB.prepare(
+			`INSERT INTO job (id, binding, state, priority, attempts, max_attempts, guarantee, payload, created_at, updated_at, seq, run_id, node_id)
+			 VALUES (?, 'REST', 'COMPLETED', 0, 1, 3, 'at-least-once', '{}', 1, 1, 9001, ?, 'list')`,
+		)
+			.bind('REST#0:linked', runId)
+			.run();
+
+		const res = await call(withAuth, 'GET', `/api/jobs/${encodeURIComponent('REST#0:linked')}`, authorized);
+		const { job } = await res.json<{ job: { run_id: string | null; node_id: string | null } }>();
+		expect(job.run_id).toBe(runId);
+		expect(job.node_id).toBe('list');
+
+		const single = await call(withAuth, 'GET', `/api/jobs/${encodeURIComponent(await seedJob())}`, authorized);
+		const { job: plain } = await single.json<{ job: { run_id: string | null; node_id: string | null } }>();
+		expect(plain.run_id).toBeNull();
+		expect(plain.node_id).toBeNull();
 	});
 
 	it('statsが最古のSCHEDULEDの経過時間を返す(#10)', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ジョブ詳細から、関連するRunの詳細を直接開けるようになりました。
  * 関連RunのIDとノード情報をジョブ詳細に表示します。
  * 単発実行など関連するRunがないジョブでは、これらの情報を空欄として扱います。

* **改善**
  * ジョブ詳細とRun詳細間の移動がスムーズになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->