### PR TITLE
fix(api): 一覧のlimitとoffsetの範囲検証

### DIFF
--- a/packages/tsumugi/src/api/rest.ts
+++ b/packages/tsumugi/src/api/rest.ts
@@ -311,11 +311,20 @@ export function groupByShard(jobIds: readonly string[]): { groups: Map<string, s
 	return { groups, invalid };
 }
 
+const LIST_LIMIT_DEFAULT = 20;
+
+// 範囲外と非整数は既定値, 負のlimitはSQLiteでは無制限
+function boundedInt(raw: string | null, fallback: number, min: number, max: number): number {
+	const value = Number(raw);
+	if (raw === null || raw === '' || !Number.isSafeInteger(value) || value < min) return fallback;
+	return Math.min(value, max);
+}
+
 /** 一覧のページング, 上限の変更漏れを避けるため両方の一覧で共有する */
 export function parsePaging(url: URL): { limit: number; offset: number } {
 	return {
-		limit: Math.min(Number(url.searchParams.get('limit') ?? 20) || 20, LIST_LIMIT_MAX),
-		offset: Math.max(Number(url.searchParams.get('offset') ?? 0) || 0, 0),
+		limit: boundedInt(url.searchParams.get('limit'), LIST_LIMIT_DEFAULT, 1, LIST_LIMIT_MAX),
+		offset: boundedInt(url.searchParams.get('offset'), 0, 0, Number.MAX_SAFE_INTEGER),
 	};
 }
 

--- a/packages/tsumugi/test/unit/paging.test.ts
+++ b/packages/tsumugi/test/unit/paging.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { parsePaging } from '../../src/api/rest.js';
+
+const parse = (query: string) => parsePaging(new URL(`https://example.com/api/jobs${query}`));
+
+describe('一覧のページング', () => {
+	it('指定が無ければ既定値を返す', () => {
+		expect(parse('')).toEqual({ limit: 20, offset: 0 });
+	});
+
+	it('指定を読み取る', () => {
+		expect(parse('?limit=50&offset=100')).toEqual({ limit: 50, offset: 100 });
+	});
+
+	it('limitを上限で切る', () => {
+		expect(parse('?limit=1000')).toEqual({ limit: 100, offset: 0 });
+	});
+
+	it('負のlimitを既定値にする', () => {
+		// SQLiteのLIMIT -1は無制限
+		expect(parse('?limit=-1')).toEqual({ limit: 20, offset: 0 });
+		expect(parse('?limit=-500')).toEqual({ limit: 20, offset: 0 });
+	});
+
+	it('小数を既定値にする', () => {
+		// D1はdatatype mismatch
+		expect(parse('?limit=1.5')).toEqual({ limit: 20, offset: 0 });
+		expect(parse('?offset=2.5')).toEqual({ limit: 20, offset: 0 });
+	});
+
+	it('安全な整数を超える値を既定値にする', () => {
+		expect(parse('?offset=1e20')).toEqual({ limit: 20, offset: 0 });
+	});
+
+	it('数値にならない値と空文字を既定値にする', () => {
+		expect(parse('?limit=abc&offset=abc')).toEqual({ limit: 20, offset: 0 });
+		expect(parse('?limit=&offset=')).toEqual({ limit: 20, offset: 0 });
+	});
+
+	it('負のoffsetを0にする', () => {
+		expect(parse('?offset=-5')).toEqual({ limit: 20, offset: 0 });
+	});
+});


### PR DESCRIPTION
`limit=-1`がSQLiteでは無制限になり一覧が全件を返すため, limitとoffsetを整数と範囲で検証する。