### PR TITLE
fix(run): spawnのID検証をconsumerへ前倒し

### DIFF
--- a/packages/tsumugi/src/core/flow.ts
+++ b/packages/tsumugi/src/core/flow.ts
@@ -223,8 +223,12 @@ function subflowNameOf(nodeId: string, name: string | undefined): string {
 	return name;
 }
 
+export function isNodeId(id: string): boolean {
+	return NODE_ID_PATTERN.test(id);
+}
+
 export function assertNodeId(id: string): void {
-	if (!NODE_ID_PATTERN.test(id)) {
+	if (!isNodeId(id)) {
 		throw new InvalidFlowError(`invalid node id: ${JSON.stringify(id)} (alphanumeric, hyphen and underscore only)`);
 	}
 }

--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -5,6 +5,7 @@ import { createClient } from '../client/enqueue.js';
 import {
 	assertDeadlineMs,
 	assertNodeId,
+	isNodeId,
 	type AnyFlow,
 	type FlowNode,
 	type Flows,
@@ -244,9 +245,16 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 
 				// 子を先に作る, 親が決着してから作ると下流が子を待たずに実行される(ADR-0032)
 				const spawned = this.#applySpawns(event.nodeId, event.spawns ?? [], now);
-				touched.push(...spawned);
+				touched.push(...spawned.ids);
 
-				this.repo.updateNode(event.nodeId, { state: event.state, result: event.result, error: event.error }, now);
+				// 子を作れない場合は親を成功にしない, 成功にすると下流が子を待たずに実行される
+				this.repo.updateNode(
+					event.nodeId,
+					spawned.error === null
+						? { state: event.state, result: event.result, error: event.error }
+						: { state: 'FAILED', error: spawned.error },
+					now,
+				);
 				touched.push(event.nodeId);
 			}
 
@@ -595,17 +603,20 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			return [row.id, ...children.map((child) => child.id)];
 		}
 
-		/** performの中で要求された子を作る, 同じIDの再要求は既存を残す(ADR-0032) */
-		#applySpawns(parentId: string, spawns: readonly SpawnRequest[], now: number): string[] {
-			if (spawns.length === 0) return [];
+		/**
+		 * performの中で要求された子を作る, 同じIDの再要求は既存を残す(ADR-0032)
+		 * 作成できない場合は例外ではなく理由を返す, 例外にすると通知が滞留する
+		 */
+		#applySpawns(parentId: string, spawns: readonly SpawnRequest[], now: number): { ids: string[]; error: string | null } {
+			if (spawns.length === 0) return { ids: [], error: null };
 			if (this.repo.countNodes() + spawns.length > maxNodes) {
-				this.repo.updateNode(parentId, { state: 'FAILED', error: `node count exceeded the limit: ${maxNodes}` }, now);
-				return [parentId];
+				return { ids: [], error: `node count exceeded the limit: ${maxNodes}` };
 			}
+			const invalid = spawns.find((spawn) => !isNodeId(spawn.id));
+			if (invalid) return { ids: [], error: `invalid spawn id: ${JSON.stringify(invalid.id)}` };
 
 			let seq = this.repo.nextSeq();
 			const children = spawns.map((spawn) => {
-				assertNodeId(spawn.id);
 				const { concurrencyKey, ...job } = spawn.options ?? {};
 				return {
 					id: `${parentId}:${spawn.id}`,
@@ -621,7 +632,7 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			});
 
 			this.repo.insertNodes(children, now);
-			return children.map((child) => child.id);
+			return { ids: children.map((child) => child.id), error: null };
 		}
 
 		/**

--- a/packages/tsumugi/src/queue/consumer.ts
+++ b/packages/tsumugi/src/queue/consumer.ts
@@ -1,4 +1,5 @@
 import type { JobContext, PerformerLike, RemoteRef } from '../core/api.js';
+import { assertNodeId } from '../core/flow.js';
 import { shardNameOf } from '../core/ids.js';
 import type { SpawnRequest } from '../core/run.js';
 import type { DispatchMessage, TsumugiJobShard } from '../do/job-shard.js';
@@ -173,6 +174,8 @@ async function handleOne<Env extends ConsumerEnv>(message: Message<DispatchMessa
 		// 要求は溜めるだけ, 送るのは完了報告と同じ便(ADR-0031)
 		// 関数はRPCのstubとして越えるので, 別Workerのperformerからも呼べる(ADR-0037)
 		const spawn = (id: string, target: string, childPayload: unknown, options?: SpawnRequest['options']) => {
+			// IDの形式検証, 不正な値はRun DOで受理できず通知が滞留する
+			assertNodeId(id);
 			spawns.push({ id, binding: target, payload: childPayload, ...(options ? { options } : {}) });
 		};
 		const stableId = jobId;

--- a/packages/tsumugi/src/testing/harness.ts
+++ b/packages/tsumugi/src/testing/harness.ts
@@ -1,4 +1,5 @@
 import type { JobContext, PerformerLike, Requirements } from '../core/api.js';
+import { assertNodeId } from '../core/flow.js';
 import type { SpawnRequest } from '../core/run.js';
 
 /**
@@ -43,6 +44,8 @@ export function createTestContext(options: TestContextOptions = {}): TestContext
 			heartbeats.push(progress);
 		},
 		spawn: (id, binding, payload, options) => {
+			// consumerと同じID検証
+			assertNodeId(id);
 			spawns.push({ id, binding, payload, ...(options ? { options } : {}) });
 		},
 	};

--- a/packages/tsumugi/test/unit/testing-harness.test.ts
+++ b/packages/tsumugi/test/unit/testing-harness.test.ts
@@ -68,6 +68,13 @@ describe('performerのハーネス', () => {
 		const result = await runPerformer(new Charge(), { customerId: 'c1' });
 		expect(result).toEqual({ ok: true, value: 'c1' });
 	});
+
+	it('spawnのIDを本番と同じ条件で検証する', () => {
+		const ctx = createTestContext();
+		ctx.spawn('child', 'Greet', {});
+		expect(ctx.spawns).toEqual([{ id: 'child', binding: 'Greet', payload: {} }]);
+		expect(() => ctx.spawn('bad id', 'Greet', {})).toThrow(/invalid node id/);
+	});
 });
 
 describe('公開している純粋関数', () => {

--- a/packages/tsumugi/test/workers/run-slice.test.ts
+++ b/packages/tsumugi/test/workers/run-slice.test.ts
@@ -187,6 +187,34 @@ describe('縦串: runの開始から完了まで', () => {
 		expect(performed.filter((p) => p.binding === 'Greet')).toHaveLength(6);
 	});
 
+	it('不正なspawnのIDはノードのFAILEDになりtickを止めない', async () => {
+		// consumerが手前で検証するので, ここへ届くのは検証を入れる前に積まれた通知だけ
+		const runId = 'GREETINGS:spawnbad';
+		const stub = runStub(runId);
+		await installQueues();
+		await stub.start({ flow: 'GREETINGS', input: { prefix: 'sb' } });
+
+		await settleRun(runId);
+		sent.length = 0;
+		const jobId = await jobIdOf(runId, 'list');
+		if (jobId === null) throw new Error('the first node has no job id');
+		await stub.notify([
+			{
+				nodeId: 'list',
+				jobId,
+				state: 'COMPLETED',
+				result: JSON.stringify({ names: ['a'] }),
+				error: null,
+				spawns: [{ id: 'bad id', binding: 'Greet', payload: {} }],
+			},
+		]);
+		await settleRun(runId);
+
+		const nodes = Object.fromEntries(await nodesOf(runId));
+		expect(nodes['list']).toBe('FAILED');
+		expect(await stateOf(runId)).toBe('FAILED');
+	});
+
 	it('ノードの失敗で下流が打ち切られrunがFAILEDになる', async () => {
 		const runId = 'GREETINGS:fail1';
 		const stub = runStub(runId);


### PR DESCRIPTION
不正なspawnのIDがRun DOの例外になりJob DOの通知が滞留するため, consumerで検証しRun DO側はノードのFAILEDとして記録する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - ノードIDの形式を一貫して検証するようになりました。
  - 不正な子ジョブIDを含む処理は適切に失敗として扱われます。
  - 動的な子ノード生成に失敗した場合、親ノードと実行全体が失敗状態になります。
  - 不正な通知が発生しても、後続の処理が停止しないよう改善しました。

- **テスト**
  - 子ジョブID、バインディング、ペイロードの検証を追加しました。
  - 不正なIDによる失敗処理を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->