### PR TITLE
fix(run): 写像関数の例外をノードのFAILEDへ変換

### DIFF
--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -488,7 +488,9 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 
 			switch (decision.type) {
 				case 'start': {
-					const built = this.#buildJob(row, definitions, runInput);
+					const evaluated = this.#evaluate(row, 'input', now, () => this.#buildJob(row, definitions, runInput));
+					if (!evaluated.ok) return [row.id];
+					const built = evaluated.value;
 					if (!built) {
 						this.repo.updateNode(row.id, { state: 'FAILED', error: `node definition is missing: ${row.id}` }, now);
 						return [row.id];
@@ -516,14 +518,13 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 						this.repo.updateNode(row.id, { state: 'FAILED', error: `invalid child run id: ${messageOf(error)}` }, now);
 						return [row.id];
 					}
+					// 子の入力は状態を書き換える前に組み立てる, 失敗した場合に起動中のノードを残さない
+					const input = this.#evaluate(row, 'input', now, () => definition.input(runInput, this.#depsOf(definition, runInput)));
+					if (!input.ok) return [row.id];
+
 					if (row.child_run_id === null) this.repo.updateNode(row.id, { childRunId }, now);
 					starting.push(row.id);
-					subflows.push({
-						nodeId: row.id,
-						childRunId,
-						flow: row.subflow,
-						input: definition.input(runInput, this.#depsOf(definition, runInput)),
-					});
+					subflows.push({ nodeId: row.id, childRunId, flow: row.subflow, input: input.value });
 					return [row.id];
 				}
 
@@ -571,32 +572,37 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 				return [row.id];
 			}
 
-			const items = definition.over(runInput, this.#depsOf(definition, runInput));
-			if (this.repo.countNodes() + items.length > maxNodes) {
+			const items = this.#evaluate(row, 'over', now, () => definition.over!(runInput, this.#depsOf(definition, runInput)));
+			if (!items.ok) return [row.id];
+			if (this.repo.countNodes() + items.value.length > maxNodes) {
 				this.repo.updateNode(row.id, { state: 'FAILED', error: `node count exceeded the limit: ${maxNodes}` }, now);
 				return [row.id];
 			}
 
 			let seq = this.repo.nextSeq();
-			const children = items.map((item, index) => {
-				const key = definition.key ? definition.key(item, index) : String(index);
-				assertNodeId(key);
-				const concurrencyKey =
-					typeof definition.childConcurrencyKey === 'function'
-						? definition.childConcurrencyKey(item, index)
-						: definition.childConcurrencyKey;
-				return {
-					id: `${row.id}:${key}`,
-					binding: definition.binding,
-					container: false,
-					parent: row.id,
-					origin: 'fanOut' as const,
-					after: [],
-					seq: seq++,
-					payload: JSON.stringify(definition.item?.(item, runInput, index) ?? null),
-					options: JSON.stringify({ ...definition.job, ...(concurrencyKey === undefined ? {} : { concurrencyKey }) }),
-				};
-			});
+			const built = this.#evaluate(row, 'fan-out', now, () =>
+				items.value.map((item, index) => {
+					const key = definition.key ? definition.key(item, index) : String(index);
+					assertNodeId(key);
+					const concurrencyKey =
+						typeof definition.childConcurrencyKey === 'function'
+							? definition.childConcurrencyKey(item, index)
+							: definition.childConcurrencyKey;
+					return {
+						id: `${row.id}:${key}`,
+						binding: definition.binding,
+						container: false,
+						parent: row.id,
+						origin: 'fanOut' as const,
+						after: [],
+						seq: seq++,
+						payload: JSON.stringify(definition.item?.(item, runInput, index) ?? null),
+						options: JSON.stringify({ ...definition.job, ...(concurrencyKey === undefined ? {} : { concurrencyKey }) }),
+					};
+				}),
+			);
+			if (!built.ok) return [row.id];
+			const children = built.value;
 
 			this.repo.insertNodes(children, now);
 			this.repo.updateNode(row.id, { state: 'RUNNING' }, now);
@@ -657,6 +663,19 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 		}
 
 		/**
+		 * flow定義の写像関数を実行する(ADR-0030)
+		 * 失敗はノードのFAILEDにする, 例外のままではtickが毎回同じ位置で停止する
+		 */
+		#evaluate<T>(row: NodeRow, label: string, now: number, run: () => T): { ok: true; value: T } | { ok: false } {
+			try {
+				return { ok: true, value: run() };
+			} catch (error) {
+				this.repo.updateNode(row.id, { state: 'FAILED', error: `${label} failed: ${messageOf(error)}` }, now);
+				return { ok: false };
+			}
+		}
+
+		/**
 		 * `when`の判定(ADR-0041)
 		 * 実行してよければnull, 実行しないなら触れたノードIDを返す
 		 */
@@ -664,13 +683,10 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			const definition = definitions.get(row.id);
 			if (!definition?.when) return null;
 
-			try {
-				if (definition.when(runInput, this.#depsOf(definition, runInput))) return null;
-			} catch (error) {
-				// 判定自体の失敗は握り潰さない, 実行の可否が決まらない
-				this.repo.updateNode(row.id, { state: 'FAILED', error: `when failed: ${messageOf(error)}` }, now);
-				return [row.id];
-			}
+			const passed = this.#evaluate(row, 'when', now, () => definition.when!(runInput, this.#depsOf(definition, runInput)));
+			if (!passed.ok) return [row.id];
+			if (passed.value) return null;
+
 			this.repo.updateNode(row.id, { state: 'SKIPPED', error: 'when returned false' }, now);
 			return [row.id];
 		}

--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -662,10 +662,7 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			};
 		}
 
-		/**
-		 * flow定義の写像関数を実行する(ADR-0030)
-		 * 失敗はノードのFAILEDにする, 例外のままではtickが毎回同じ位置で停止する
-		 */
+		// 失敗はノードのFAILEDにする, 例外のままではtickが毎回同じ位置で停止する
 		#evaluate<T>(row: NodeRow, label: string, now: number, run: () => T): { ok: true; value: T } | { ok: false } {
 			try {
 				return { ok: true, value: run() };

--- a/packages/tsumugi/test/workers/run-slice.test.ts
+++ b/packages/tsumugi/test/workers/run-slice.test.ts
@@ -135,6 +135,9 @@ async function settleRun(runId: string, rounds = 8): Promise<void> {
 const stateOf = (runId: string) =>
 	runInDurableObject(runStub(runId), (instance) => (instance as any).repo.findRun()?.state as string | undefined);
 
+const errorOf = (runId: string, nodeId: string) =>
+	runInDurableObject(runStub(runId), (instance) => (instance as any).repo.findNode(nodeId)?.error as string | null);
+
 describe('縦串: runの開始から完了まで', () => {
 	it('fan-outを含むflowが最後まで進む', async () => {
 		performed.length = 0;
@@ -212,6 +215,19 @@ describe('縦串: runの開始から完了まで', () => {
 
 		const nodes = Object.fromEntries(await nodesOf(runId));
 		expect(nodes['list']).toBe('FAILED');
+		expect(await stateOf(runId)).toBe('FAILED');
+	});
+
+	it('写像関数の例外はノードのFAILEDになる', async () => {
+		const runId = 'GREETINGS:mapfail';
+		const stub = runStub(runId);
+		await installQueues();
+		// inputがnullなので`list`のinputがTypeErrorになる
+		await stub.start({ flow: 'GREETINGS', input: null });
+		await settleRun(runId);
+
+		expect(Object.fromEntries(await nodesOf(runId))).toEqual({ list: 'FAILED', greet: 'SKIPPED', report: 'SKIPPED' });
+		expect(await errorOf(runId, 'list')).toMatch(/^input failed:/);
 		expect(await stateOf(runId)).toBe('FAILED');
 	});
 


### PR DESCRIPTION
input / over / key / concurrencyKeyの例外がtickごと中断させRun DOが5秒間隔で再実行を繰り返すため, whenと同じくノードのFAILEDとして記録する。