### PR TITLE
fix(auth): cookieのトークンをURLデコード

### DIFF
--- a/packages/tsumugi/src/api/access.ts
+++ b/packages/tsumugi/src/api/access.ts
@@ -1,4 +1,4 @@
-import type { AuthMiddleware } from './auth.js';
+import { readCookie, type AuthMiddleware } from './auth.js';
 
 /**
  * Cloudflare AccessのJWT検証
@@ -121,13 +121,4 @@ export function cloudflareAccess(options: AccessOptions): AuthMiddleware {
 		c.set('accessClaims', claims);
 		await next();
 	};
-}
-
-function readCookie(header: string | undefined, name: string): string | undefined {
-	if (!header) return undefined;
-	for (const part of header.split(';')) {
-		const [key, ...rest] = part.trim().split('=');
-		if (key === name) return rest.join('=');
-	}
-	return undefined;
 }

--- a/packages/tsumugi/src/api/auth.ts
+++ b/packages/tsumugi/src/api/auth.ts
@@ -30,11 +30,19 @@ export type BearerOptions = {
 	cookie?: string;
 };
 
-function readCookie(header: string | undefined, name: string): string | undefined {
+export function readCookie(header: string | undefined, name: string): string | undefined {
 	if (!header) return undefined;
 	for (const part of header.split(';')) {
 		const [key, ...rest] = part.trim().split('=');
-		if (key === name) return rest.join('=');
+		if (key !== name) continue;
+		const value = rest.join('=');
+		// 書き出し側のencodeURIComponentを戻す, 復号しないとbase64の`+ / =`が一致しない
+		try {
+			return decodeURIComponent(value);
+		} catch {
+			// 不正な%列は素の値で比較する, 例外にすると401ではなく500になる
+			return value;
+		}
 	}
 	return undefined;
 }

--- a/packages/tsumugi/test/unit/auth.test.ts
+++ b/packages/tsumugi/test/unit/auth.test.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { bearerAuth } from '../../src/api/auth.js';
+
+/** base64のsecretに現れる文字, ダッシュボードはこれをencodeURIComponentしてcookieへ書く */
+const TOKEN = 'sk+ab/cd=';
+
+const appWith = (token: string) => {
+	const app = new Hono();
+	app.use('/api/*', bearerAuth(token, { cookie: 'tsumugi_token' }));
+	app.get('/api/ping', (c) => c.text('ok'));
+	return app;
+};
+
+const get = (token: string, headers: Record<string, string>) => appWith(token).request('/api/ping', { headers });
+
+describe('bearerAuth', () => {
+	it('Authorizationヘッダを受け付ける', async () => {
+		expect((await get(TOKEN, { authorization: `Bearer ${TOKEN}` })).status).toBe(200);
+	});
+
+	it('URLエンコード済みのcookieを受け付ける', async () => {
+		const cookie = `tsumugi_token=${encodeURIComponent(TOKEN)}`;
+		expect((await get(TOKEN, { cookie })).status).toBe(200);
+	});
+
+	it('エンコード不要なトークンのcookieを受け付ける', async () => {
+		expect((await get('plain-token', { cookie: 'tsumugi_token=plain-token' })).status).toBe(200);
+	});
+
+	it('不正な%列のcookieは401', async () => {
+		expect((await get(TOKEN, { cookie: 'tsumugi_token=%E0%A4%A' })).status).toBe(401);
+	});
+
+	it('他のcookieが並んでいても読み取る', async () => {
+		const cookie = `other=1; tsumugi_token=${encodeURIComponent(TOKEN)}; last=2`;
+		expect((await get(TOKEN, { cookie })).status).toBe(200);
+	});
+
+	it('cookieもヘッダも無ければ401', async () => {
+		expect((await get(TOKEN, {})).status).toBe(401);
+	});
+});


### PR DESCRIPTION
ダッシュボードがencodeURIComponentして書き込むため, base64のsecretなど`+ / =`を含むトークンがcookie経路で常に401になる。