### PR TITLE
fix(access): 不正なJWTを500ではなく401に

### DIFF
--- a/packages/tsumugi/src/api/access.ts
+++ b/packages/tsumugi/src/api/access.ts
@@ -74,17 +74,22 @@ export async function verifyAccessJwt(token: string, options: AccessOptions, now
 	const jwk = jwks.keys.find((key) => key.kid === header.kid);
 	if (!jwk) return null;
 
-	const key = await crypto.subtle.importKey(
-		'jwk',
-		{ ...jwk, alg: 'RS256', ext: true },
-		{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-		false,
-		['verify'],
-	);
-	const signed = new TextEncoder().encode(`${headerSegment}.${payloadSegment}`);
-	const signature = base64UrlToBytes(signatureSegment);
-	const ok = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, signed);
-	return ok ? claims : null;
+	// 署名部の復号と鍵の取り込みの失敗も検証の失敗として扱う, 例外のままでは401ではなく500になる
+	try {
+		const key = await crypto.subtle.importKey(
+			'jwk',
+			{ ...jwk, alg: 'RS256', ext: true },
+			{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+			false,
+			['verify'],
+		);
+		const signed = new TextEncoder().encode(`${headerSegment}.${payloadSegment}`);
+		const signature = base64UrlToBytes(signatureSegment);
+		const ok = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, signed);
+		return ok ? claims : null;
+	} catch {
+		return null;
+	}
 }
 
 const jwksCache = new Map<string, { jwks: Jwks; expiresAt: number }>();

--- a/packages/tsumugi/test/workers/access.test.ts
+++ b/packages/tsumugi/test/workers/access.test.ts
@@ -134,6 +134,18 @@ describe('Access JWTの検証', () => {
 		}
 	});
 
+	it('署名部がbase64でなければ拒否する', async () => {
+		const token = await makeJwt(validClaims());
+		const [header, payload] = token.split('.') as [string, string, string];
+		expect(await verifyAccessJwt(`${header}.${payload}.not base64!`, options(), Date.now())).toBeNull();
+	});
+
+	it('JWKSの鍵が壊れていれば拒否する', async () => {
+		const token = await makeJwt(validClaims());
+		const broken = { ...options(), fetchJwks: async () => ({ keys: [{ kty: 'RSA', kid: KID, n: '!!', e: 'AQAB' }] }) };
+		expect(await verifyAccessJwt(token, broken, Date.now())).toBeNull();
+	});
+
 	it('audが配列でも一致すれば通る', async () => {
 		const token = await makeJwt(validClaims({ aud: ['other', AUD] }));
 		expect(await verifyAccessJwt(token, options(), Date.now())).not.toBeNull();


### PR DESCRIPTION
署名部の復号と鍵の取り込みがtry/catchの外にあり, base64でない署名や壊れたJWKSが認証失敗ではなく500になる。