### PR TITLE
fix(api): 一括操作でshardの失敗を個別の結果として返すように

### DIFF
--- a/packages/spec/models.tsp
+++ b/packages/spec/models.tsp
@@ -194,8 +194,8 @@ model BulkResult {
 	failed: {
 		id: string;
 
-		@doc("invalid-state matches 409, gone matches 410, invalid-id is a malformed job id")
-		reason: "invalid-state" | "gone" | "invalid-id";
+		@doc("invalid-state matches 409, gone matches 410, invalid-id is a malformed job id, unreachable means the shard did not respond")
+		reason: "invalid-state" | "gone" | "invalid-id" | "unreachable";
 	}[];
 
 	@doc("Estimated matches left after the limit. Always 0 when ids was given.")

--- a/packages/tsumugi/src/api/rest.ts
+++ b/packages/tsumugi/src/api/rest.ts
@@ -610,15 +610,26 @@ export function createRest<Env extends RestEnv>(auth: AuthMiddleware, options: R
 		}
 
 		const { groups, invalid } = groupByShard(targets);
-		const results = await Promise.all(
-			[...groups].map(([name, ids]) => env.JOB_SHARD.get(env.JOB_SHARD.idFromName(name)).mutateMany(action, ids)),
+		const entries = [...groups];
+		// 届かなかったshardも個別の失敗として返す, 全体を500にすると成功した分まで再送される
+		const settled = await Promise.allSettled(
+			entries.map(([name, ids]) => env.JOB_SHARD.get(env.JOB_SHARD.idFromName(name)).mutateMany(action, ids)),
+		);
+		for (const [index, result] of settled.entries()) {
+			if (result.status === 'rejected') console.error(`tsumugi: bulk ${action} failed on ${entries[index]?.[0]}`, result.reason);
+		}
+
+		const applied = settled.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []));
+		const unreachable = settled.flatMap((result, index) =>
+			result.status === 'rejected' ? (entries[index]?.[1] ?? []).map((id) => ({ id, reason: 'unreachable' as const })) : [],
 		);
 
-		const failed: (BulkFailure | { id: string; reason: 'invalid-id' })[] = [
-			...results.flatMap((result) => result.failed),
+		const failed: (BulkFailure | { id: string; reason: 'invalid-id' | 'unreachable' })[] = [
+			...applied.flatMap((result) => result.failed),
 			...invalid.map((id) => ({ id, reason: 'invalid-id' as const })),
+			...unreachable,
 		];
-		return { body: { ok: results.flatMap((result) => result.ok), failed, remaining }, status: 200 } as const;
+		return { body: { ok: applied.flatMap((result) => result.ok), failed, remaining }, status: 200 } as const;
 	};
 
 	for (const action of ['retry', 'cancel'] as const) {

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -810,7 +810,6 @@ describe('一括リトライと一括取り消し', () => {
 		return job.state;
 	};
 
-	/** 名前で応答を切り替えるJOB_SHARD, shard単位の失敗だけを作る */
 	const shardsFailing = (unreachable: readonly string[]) => ({
 		idFromName: (name: string) => name,
 		get: (name: string) => ({

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { bearerAuth, unsafeNoAuth } from '../../src/entries/index.js';
 import { Performer } from '../../src/performer/entrypoint.js';
 import { defineTsumugi } from '../../src/worker.js';
-import { SORTABLE_COLUMNS, type RestEnv } from '../../src/api/rest.js';
+import { createRest, SORTABLE_COLUMNS, type RestEnv } from '../../src/api/rest.js';
 import { ERROR_MAX_CHARS } from '../../src/do/repo.js';
 
 const T0 = 2_200_000_000_000;
@@ -809,6 +809,34 @@ describe('一括リトライと一括取り消し', () => {
 		const { job } = await res.json<{ job: { state: string } }>();
 		return job.state;
 	};
+
+	it('応答しないshardの対象をunreachableとして返す', async () => {
+		// 1つのshardが応答しなくても200で返す, 500にすると成功した分まで再送される
+		const app = createRest(bearerAuth(TOKEN), { bindings: ['REST'] });
+		const broken = {
+			idFromName: (name: string) => name,
+			get: () => ({
+				mutateMany: async () => {
+					throw new Error('shard is unreachable');
+				},
+			}),
+		};
+		const res = await app.request(
+			'/api/jobs/bulk-retry',
+			{ method: 'POST', headers: authorized, body: JSON.stringify({ ids: ['REST#0:a', 'REST#0:b'] }) },
+			{ ...env, JOB_SHARD: broken } as unknown as RestEnv,
+		);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			ok: [],
+			failed: [
+				{ id: 'REST#0:a', reason: 'unreachable' },
+				{ id: 'REST#0:b', reason: 'unreachable' },
+			],
+			remaining: 0,
+		});
+	});
 
 	it('選択したIDをまとめてリトライする', async () => {
 		const jobId = await failedJob();

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -810,22 +810,27 @@ describe('一括リトライと一括取り消し', () => {
 		return job.state;
 	};
 
+	/** 名前で応答を切り替えるJOB_SHARD, shard単位の失敗だけを作る */
+	const shardsFailing = (unreachable: readonly string[]) => ({
+		idFromName: (name: string) => name,
+		get: (name: string) => ({
+			mutateMany: async (_action: string, ids: string[]) => {
+				if (unreachable.includes(name)) throw new Error('shard is unreachable');
+				return { ok: ids, failed: [] };
+			},
+		}),
+	});
+
+	const bulkWith = (shards: unknown, ids: string[]) =>
+		createRest(bearerAuth(TOKEN), { bindings: ['REST'] }).request(
+			'/api/jobs/bulk-retry',
+			{ method: 'POST', headers: authorized, body: JSON.stringify({ ids }) },
+			{ ...env, JOB_SHARD: shards } as unknown as RestEnv,
+		);
+
 	it('応答しないshardの対象をunreachableとして返す', async () => {
 		// 1つのshardが応答しなくても200で返す, 500にすると成功した分まで再送される
-		const app = createRest(bearerAuth(TOKEN), { bindings: ['REST'] });
-		const broken = {
-			idFromName: (name: string) => name,
-			get: () => ({
-				mutateMany: async () => {
-					throw new Error('shard is unreachable');
-				},
-			}),
-		};
-		const res = await app.request(
-			'/api/jobs/bulk-retry',
-			{ method: 'POST', headers: authorized, body: JSON.stringify({ ids: ['REST#0:a', 'REST#0:b'] }) },
-			{ ...env, JOB_SHARD: broken } as unknown as RestEnv,
-		);
+		const res = await bulkWith(shardsFailing(['REST#0']), ['REST#0:a', 'REST#0:b']);
 
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
@@ -834,6 +839,18 @@ describe('一括リトライと一括取り消し', () => {
 				{ id: 'REST#0:a', reason: 'unreachable' },
 				{ id: 'REST#0:b', reason: 'unreachable' },
 			],
+			remaining: 0,
+		});
+	});
+
+	it('応答したshardの結果は残す', async () => {
+		// 成功した分を結果に含めないと呼び出し側が再送し、同じ操作を二度実行する
+		const res = await bulkWith(shardsFailing(['REST#1']), ['REST#0:a', 'REST#1:b']);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			ok: ['REST#0:a'],
+			failed: [{ id: 'REST#1:b', reason: 'unreachable' }],
 			remaining: 0,
 		});
 	});


### PR DESCRIPTION
Promise.allのため1つのshardが応答しないと全体が500になり成功した分まで再送されるため, allSettledに変えreasonにunreachableを追加する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 一括リトライ・キャンセル処理で、一部のシャードが応答しない場合も処理を継続できるようになりました。
  - 到達できなかった対象は、失敗理由として `unreachable` で確認できます。
  - 到達可能な対象の結果は従来どおり返され、部分的な成功にも対応しました。
  - シャード障害時も適切なレスポンスを返し、処理結果を確認しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->