### PR TITLE
fix(do): レート制限の残りトークンを永続化

### DIFF
--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -155,7 +155,6 @@ const FAILURE_NOTIFY_LIMIT = 200;
 /** 宛先を置く設定のキー(#30) */
 const FAILURE_BINDING_KEY = 'failure_binding';
 
-/** 残りトークンを置く設定のキー(ADR-0009) */
 const BUCKET_KEY = 'rate_bucket';
 
 /** 済んだジョブをDOに残す時間,投影が追いつく余裕を見て既定5分 */
@@ -290,10 +289,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		this.#blockedLoaded = true;
 	}
 
-	/**
-	 * 残りトークンを一度だけ読み戻す(ADR-0009)
-	 * メモリだけで持つとDOの退避で満タンに戻り、設定した流量を超えて投入される
-	 */
+	// メモリだけで持つとDOの退避で満タンに戻り、設定した流量を超えて投入される
 	#loadBucket(): void {
 		if (this.#bucketLoaded) return;
 		const raw = this.repo.readSetting(BUCKET_KEY);
@@ -304,10 +300,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		this.#bucketLoaded = true;
 	}
 
-	/**
-	 * 残りトークンを保存する
-	 * 満タンの状態は書かない, 読み戻す時のrefillで同じ値になるので毎tickの書き込みだけが増える
-	 */
+	// 満タンの状態は書かない, 読み戻す時のrefillで同じ値になるので毎tickの書き込みだけが増える
 	#persistBucket(bucket: Bucket): void {
 		const rate = this.policy.rate;
 		if (rate === null || bucket.tokens >= rate.tokens) return;

--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -292,7 +292,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 
 	/**
 	 * 残りトークンを一度だけ読み戻す(ADR-0009)
-	 * メモリだけで持つとDOの退避で満タンに戻り, 設定した流量を超えて投入される
+	 * メモリだけで持つとDOの退避で満タンに戻り、設定した流量を超えて投入される
 	 */
 	#loadBucket(): void {
 		if (this.#bucketLoaded) return;

--- a/packages/tsumugi/src/do/job-shard.ts
+++ b/packages/tsumugi/src/do/job-shard.ts
@@ -155,6 +155,9 @@ const FAILURE_NOTIFY_LIMIT = 200;
 /** 宛先を置く設定のキー(#30) */
 const FAILURE_BINDING_KEY = 'failure_binding';
 
+/** 残りトークンを置く設定のキー(ADR-0009) */
+const BUCKET_KEY = 'rate_bucket';
+
 /** 済んだジョブをDOに残す時間,投影が追いつく余裕を見て既定5分 */
 const DEFAULT_SWEEP_AFTER_MS = 5 * 60 * 1000;
 
@@ -187,6 +190,7 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 
 	#repo: JobRepo | undefined;
 	#bucket: Bucket = { tokens: Number.POSITIVE_INFINITY, refilledAt: 0 };
+	#bucketLoaded = false;
 	#policyLoaded = false;
 	/** 直近tickで投入が止まった制約, 診断で外へ出す(#10) */
 	#lastBlocked: BlockedBy = { paused: false, capacity: false, tokens: false, perKey: false };
@@ -284,6 +288,30 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 		const raw = this.repo.readSetting('last_blocked');
 		if (raw) this.#lastBlocked = { ...this.#lastBlocked, ...(JSON.parse(raw) as Partial<BlockedBy>) };
 		this.#blockedLoaded = true;
+	}
+
+	/**
+	 * 残りトークンを一度だけ読み戻す(ADR-0009)
+	 * メモリだけで持つとDOの退避で満タンに戻り, 設定した流量を超えて投入される
+	 */
+	#loadBucket(): void {
+		if (this.#bucketLoaded) return;
+		const raw = this.repo.readSetting(BUCKET_KEY);
+		if (raw) {
+			const stored = JSON.parse(raw) as Bucket;
+			if (Number.isFinite(stored.tokens) && Number.isFinite(stored.refilledAt)) this.#bucket = stored;
+		}
+		this.#bucketLoaded = true;
+	}
+
+	/**
+	 * 残りトークンを保存する
+	 * 満タンの状態は書かない, 読み戻す時のrefillで同じ値になるので毎tickの書き込みだけが増える
+	 */
+	#persistBucket(bucket: Bucket): void {
+		const rate = this.policy.rate;
+		if (rate === null || bucket.tokens >= rate.tokens) return;
+		this.repo.writeSetting(BUCKET_KEY, JSON.stringify(bucket));
 	}
 
 	/** blockedを保存する,変化した時だけ書いて毎tickの書き込みを避ける(#10) */
@@ -573,9 +601,11 @@ export class TsumugiJobShard extends DurableObject<ShardEnv> {
 	async #tick(): Promise<void> {
 		const now = this.clock.now();
 		this.#loadPolicy();
+		this.#loadBucket();
 		const { jobs, readyCount } = this.repo.scheduleWindow(now, TICK_LIMIT);
 		const output = schedule({ now, jobs, policy: this.policy, bucket: this.#bucket });
 		this.#bucket = output.bucket;
+		this.#persistBucket(output.bucket);
 		// どの制約で投入が止まったかを診断で外へ出す,DO退避後も残す(#10)
 		this.#persistBlocked(output.blocked);
 

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -279,7 +279,7 @@ describe('トークンバケットの永続化(ADR-0009)', () => {
 		runInDurableObject(shard(name), (instance) => (instance as any).repo.readSetting('rate_bucket') as string | undefined);
 
 	it('消費した残りをSQLiteへ保存する', async () => {
-		// メモリだけで持つとDOの退避で満タンに戻り, 設定した流量を超えて投入される
+		// メモリだけで持つとDOの退避で満タンに戻り、設定した流量を超えて投入される
 		const { queue, sent } = captureQueue();
 		await install('BUCKET1#0', T0, queue);
 		await shard('BUCKET1#0').configure({ policy: { rate: { tokens: 2, intervalMs: 60_000 } } });
@@ -292,7 +292,7 @@ describe('トークンバケットの永続化(ADR-0009)', () => {
 	});
 
 	it('満タンなら保存しない', async () => {
-		// 読み戻す時のrefillで同じ値になるので, 書き込みだけが増える
+		// 読み戻す時のrefillで同じ値になるので、書き込みだけが増える
 		const { queue } = captureQueue();
 		await install('BUCKET2#0', T0, queue);
 		await shard('BUCKET2#0').configure({ policy: { rate: { tokens: 10, intervalMs: 60_000 } } });

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -309,4 +309,18 @@ describe('トークンバケットの永続化(ADR-0009)', () => {
 
 		expect(await bucketOf('BUCKET3#0')).toBeUndefined();
 	});
+
+	it('保存した残りを読み戻して投入を抑える', async () => {
+		// DOの退避は再現できない, 初回tickの前にSQLiteへ直接書いて同じ状態にする
+		const { queue, sent } = captureQueue();
+		await install('BUCKET4#0', T0, queue);
+		await runInDurableObject(shard('BUCKET4#0'), (instance) =>
+			(instance as any).repo.writeSetting('rate_bucket', JSON.stringify({ tokens: 0, refilledAt: T0 })),
+		);
+		await shard('BUCKET4#0').configure({ policy: { rate: { tokens: 2, intervalMs: 60_000 } } });
+		for (let i = 0; i < 3; i++) await shard('BUCKET4#0').enqueue({ binding: 'BUCKET4', payload: { i } });
+		await runDurableObjectAlarm(shard('BUCKET4#0'));
+
+		expect(sent).toHaveLength(0);
+	});
 });

--- a/packages/tsumugi/test/workers/scale.test.ts
+++ b/packages/tsumugi/test/workers/scale.test.ts
@@ -273,3 +273,40 @@ describe('投入候補の読み取り範囲(ADR-0019 / ADR-0020, #4)', () => {
 		expect(await stateOf('WIN#0', late)).toBe('QUEUED');
 	});
 });
+
+describe('トークンバケットの永続化(ADR-0009)', () => {
+	const bucketOf = (name: string) =>
+		runInDurableObject(shard(name), (instance) => (instance as any).repo.readSetting('rate_bucket') as string | undefined);
+
+	it('消費した残りをSQLiteへ保存する', async () => {
+		// メモリだけで持つとDOの退避で満タンに戻り, 設定した流量を超えて投入される
+		const { queue, sent } = captureQueue();
+		await install('BUCKET1#0', T0, queue);
+		await shard('BUCKET1#0').configure({ policy: { rate: { tokens: 2, intervalMs: 60_000 } } });
+		for (let i = 0; i < 5; i++) await shard('BUCKET1#0').enqueue({ binding: 'BUCKET1', payload: { i } });
+		await runDurableObjectAlarm(shard('BUCKET1#0'));
+
+		// 上限まで投入したので残りは0
+		expect(sent).toHaveLength(2);
+		expect(JSON.parse((await bucketOf('BUCKET1#0')) as string)).toEqual({ tokens: 0, refilledAt: T0 });
+	});
+
+	it('満タンなら保存しない', async () => {
+		// 読み戻す時のrefillで同じ値になるので, 書き込みだけが増える
+		const { queue } = captureQueue();
+		await install('BUCKET2#0', T0, queue);
+		await shard('BUCKET2#0').configure({ policy: { rate: { tokens: 10, intervalMs: 60_000 } } });
+		await runDurableObjectAlarm(shard('BUCKET2#0'));
+
+		expect(await bucketOf('BUCKET2#0')).toBeUndefined();
+	});
+
+	it('流量制限が無ければ保存しない', async () => {
+		const { queue } = captureQueue();
+		await install('BUCKET3#0', T0, queue);
+		await shard('BUCKET3#0').enqueue({ binding: 'BUCKET3', payload: {} });
+		await runDurableObjectAlarm(shard('BUCKET3#0'));
+
+		expect(await bucketOf('BUCKET3#0')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
トークンバケットがメモリのみのためDOの退避ごとに満タンから再開し設定した流量を超えるので, 満タン以外をSQLiteへ保存する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * レート制限の状態を永続化し、処理の一時停止や再起動後もトークン残量と補充タイミングを維持できるようにしました。
  * 不要な状態は保存せず、設定がない場合やバケットが満タンの場合の動作を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->