### PR TITLE
fix(dashboard): トークンcookieにSecureを付与

### DIFF
--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -48,10 +48,13 @@ export function isUnauthorized(error: unknown): boolean {
 	return typeof error === 'object' && error !== null && (error as { unauthorized?: unknown }).unauthorized === true;
 }
 
+/** httpsの時だけSecureを付ける, wrangler devはhttpで動くので常時付けると開発時に保存できない */
+export const cookieAttributes = (protocol: string): string => `path=/; SameSite=Strict${protocol === 'https:' ? '; Secure' : ''}`;
+
 export function saveToken(value: string): void {
 	const name = tokenCookie();
 	if (!name) return;
-	document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Strict`;
+	document.cookie = `${name}=${encodeURIComponent(value)}; ${cookieAttributes(location.protocol)}`;
 }
 
 async function call<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/packages/dashboard/test/unit/cookie.test.ts
+++ b/packages/dashboard/test/unit/cookie.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { cookieAttributes } from '../../src/api';
+
+describe('トークンcookieの属性', () => {
+	it('httpsではSecureを付ける', () => {
+		expect(cookieAttributes('https:')).toBe('path=/; SameSite=Strict; Secure');
+	});
+
+	it('httpでは付けない', () => {
+		// wrangler devはhttpで動くので, 付けるとブラウザが保存しない
+		expect(cookieAttributes('http:')).toBe('path=/; SameSite=Strict');
+	});
+});


### PR DESCRIPTION
トークンcookieにSecureが無く平文で送出され得るため, httpsの時だけ付与する。
