### PR TITLE
fix: 登録の照合をObject.hasOwnに統一

### DIFF
--- a/packages/tsumugi/src/client/enqueue.ts
+++ b/packages/tsumugi/src/client/enqueue.ts
@@ -45,7 +45,6 @@ export type TsumugiClient<Env extends ClientEnv> = {
 	shardFor(env: Env, binding: string, partitionKey?: string): DurableObjectStub<JobShardStub>;
 };
 
-/** 自身のキーだけを見る,`bindings[binding]`はconstructor等でObject.prototypeまで辿る */
 export const configOf = (bindings: Record<string, BindingConfig>, binding: string): BindingConfig | undefined =>
 	Object.hasOwn(bindings, binding) ? bindings[binding] : undefined;
 

--- a/packages/tsumugi/src/client/enqueue.ts
+++ b/packages/tsumugi/src/client/enqueue.ts
@@ -45,6 +45,10 @@ export type TsumugiClient<Env extends ClientEnv> = {
 	shardFor(env: Env, binding: string, partitionKey?: string): DurableObjectStub<JobShardStub>;
 };
 
+/** 自身のキーだけを見る,`bindings[binding]`はconstructor等でObject.prototypeまで辿る */
+export const configOf = (bindings: Record<string, BindingConfig>, binding: string): BindingConfig | undefined =>
+	Object.hasOwn(bindings, binding) ? bindings[binding] : undefined;
+
 /** binding個別の設定と全体で共通の設定を1つにまとめる, DOへ渡る形は1つ */
 function settingsOf(config: BindingConfig | undefined, common: CommonSettings): ShardSettings | undefined {
 	const hasBinding = config?.policy || config?.sweepAfterMs !== undefined || config?.failedRetentionMs !== undefined;
@@ -76,7 +80,7 @@ export function createClient<Env extends ClientEnv>(
 	common: CommonSettings = {},
 ): TsumugiClient<Env> {
 	const shardOf = (env: Env, binding: string, partitionKey: string | undefined) => {
-		const config = bindings[binding];
+		const config = configOf(bindings, binding);
 		const shard = resolveShard(binding, config?.shards ?? 1, partitionKey);
 		const ns = env.JOB_SHARD as DurableObjectNamespace<JobShardStub>;
 		return {

--- a/packages/tsumugi/src/do/run.ts
+++ b/packages/tsumugi/src/do/run.ts
@@ -1,7 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 import { createId } from '@paralleldrive/cuid2';
 import type { BindingConfig, ClientEnv } from '../client/enqueue.js';
-import { createClient } from '../client/enqueue.js';
+import { configOf, createClient } from '../client/enqueue.js';
 import {
 	assertDeadlineMs,
 	assertNodeId,
@@ -180,7 +180,7 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			const existing = this.repo.findRun();
 			if (existing) return { id: runId, created: false };
 
-			const flow = flows[input.flow];
+			const flow = Object.hasOwn(flows, input.flow) ? flows[input.flow] : undefined;
 			if (!flow) throw new Error(`flow is not registered: ${input.flow}`);
 
 			const depth = input.depth ?? 0;
@@ -349,7 +349,7 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 			const runRow = this.repo.findRun();
 			if (!runRow) return;
 
-			const flow = flows[runRow.flow];
+			const flow = Object.hasOwn(flows, runRow.flow) ? flows[runRow.flow] : undefined;
 			if (!flow) {
 				// 定義ごと消えた, 待っても解決しないので理由を残して落とす(ADR-0030)
 				this.#failRun(runRow.id, `flow is not registered: ${runRow.flow}`, now);
@@ -684,7 +684,7 @@ export function createRunClass({ flows, bindings, settings = {}, failureBinding 
 
 		#shardOf(binding: string, runId: string): number {
 			// runIdをpartitionKeyにする, run内のノードが同じshardに集まりRun DO側でIDを決められる(ADR-0011)
-			return resolveShard(binding, bindings[binding]?.shards ?? 1, runId);
+			return resolveShard(binding, configOf(bindings, binding)?.shards ?? 1, runId);
 		}
 
 		/**

--- a/packages/tsumugi/src/do/scheduler.ts
+++ b/packages/tsumugi/src/do/scheduler.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
-import { createClient, type BindingConfig, type ClientEnv } from '../client/enqueue.js';
+import { configOf, createClient, type BindingConfig, type ClientEnv } from '../client/enqueue.js';
 import { formatJobId, formatRunId, shardNameOf } from '../core/ids.js';
 import { normalizeSchedules, nextOccurrence, type AnyScheduleDef, type AnySchedules, type ScheduleContext } from '../core/recurring.js';
 import { resolveShard } from '../core/shard.js';
@@ -93,7 +93,7 @@ export function createSchedulerClass({ schedules, bindings, targets, failureBind
 	const { schedules: normalized, fingerprint } = normalizeSchedules(schedules, {
 		bindings: targets.bindings,
 		flows: targets.flows,
-		shardsOf: (binding) => bindings[binding]?.shards ?? 1,
+		shardsOf: (binding) => configOf(bindings, binding)?.shards ?? 1,
 	});
 	const client = createClient<SchedulerEnv>(bindings, failureBinding === undefined ? {} : { failureBinding });
 
@@ -158,7 +158,7 @@ export function createSchedulerClass({ schedules, bindings, targets, failureBind
 				this.#reconcile(now);
 
 				for (const row of this.repo.due(now, TICK_LIMIT)) {
-					const def = schedules[row.name];
+					const def = Object.hasOwn(schedules, row.name) ? schedules[row.name] : undefined;
 					if (!def) {
 						// reconcileで消えているはずの防御, 定義の無い行は発火できない
 						this.repo.remove([row.name]);
@@ -213,7 +213,7 @@ export function createSchedulerClass({ schedules, bindings, targets, failureBind
 				if (row.kind === 'job') {
 					const binding = def.binding as string;
 					// 決定的IDにする, 再発火しても同じIDの再投入は既存を返す(ADR-0029)
-					const shard = resolveShard(binding, bindings[binding]?.shards ?? 1, def.partitionKey);
+					const shard = resolveShard(binding, configOf(bindings, binding)?.shards ?? 1, def.partitionKey);
 					const jobId = formatJobId({ binding, shard, localId: `${row.name}-${occurrence}` });
 					await client.enqueue(this.env, {
 						binding,

--- a/packages/tsumugi/src/worker.ts
+++ b/packages/tsumugi/src/worker.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import { assertValidFlow, formatRunId, shardName } from './core/ids.js';
-import { createClient, type BindingConfig, type ClientEnv } from './client/enqueue.js';
+import { configOf, createClient, type BindingConfig, type ClientEnv } from './client/enqueue.js';
 import { DEFAULT_FAILED_RETENTION_MS } from './do/job-shard.js';
 import type { DispatchMessage, EnqueueInput, MutationResult, TsumugiJobShard } from './do/job-shard.js';
 import { createRunClass, type RunClass, type RunSettings, type StartResult } from './do/run.js';
@@ -232,7 +232,7 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 
 	const start = async (env: Env, flow: string, input: unknown, options?: StartOptions): Promise<string> => {
 		assertConfigured(env);
-		if (!flows[flow]) throw new Error(`flow is not registered: ${flow}`);
+		if (!Object.hasOwn(flows, flow)) throw new Error(`flow is not registered: ${flow}`);
 		const runId = formatRunId({ flow, localId: options?.id ?? createId() });
 		const result = await runFor(env, runId).start({
 			flow,
@@ -247,10 +247,10 @@ export function defineTsumugi<const R extends PerformerRegistry<any>, const F ex
 				...(config.ui ? { dashboard: config.ui } : {}),
 				bindings: Object.keys(performers),
 				// 流量の変更を全shardへ配るために必要(#27)
-				shardsOf: (binding) => config.bindings?.[binding]?.shards ?? 1,
+				shardsOf: (binding) => configOf(config.bindings ?? {}, binding)?.shards ?? 1,
 				enqueue: (env, input) => client.enqueue(env, input),
 				// 一覧のretryable判定に使う, UI側が押す前に可否を出せるようにする(ADR-0027)
-				failedRetentionMs: (binding) => config.bindings?.[binding]?.failedRetentionMs ?? DEFAULT_FAILED_RETENTION_MS,
+				failedRetentionMs: (binding) => configOf(config.bindings ?? {}, binding)?.failedRetentionMs ?? DEFAULT_FAILED_RETENTION_MS,
 				flows: Object.keys(flows),
 				// 未設定なら渡さない, `/api/metrics`は501を返す
 				...(config.metrics ? { metrics: config.metrics as MetricsResolver<Env> } : {}),

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -988,4 +988,10 @@ describe('runの開始', () => {
 		const res = await post({ flow: 'UNKNOWN', input: {} });
 		expect(res.status).toBe(400);
 	});
+
+	it('Object.prototypeの名前を登録済みとして扱わない', async () => {
+		// `flows[flow]`のままだとconstructorやtoStringが真の値として返る
+		await expect(withFlows.start(env as never, 'constructor' as never, {} as never)).rejects.toThrow(/flow is not registered/);
+		await expect(withFlows.start(env as never, 'toString' as never, {} as never)).rejects.toThrow(/flow is not registered/);
+	});
 });

--- a/packages/tsumugi/test/workers/rest.test.ts
+++ b/packages/tsumugi/test/workers/rest.test.ts
@@ -990,7 +990,6 @@ describe('runの開始', () => {
 	});
 
 	it('Object.prototypeの名前を登録済みとして扱わない', async () => {
-		// `flows[flow]`のままだとconstructorやtoStringが真の値として返る
 		await expect(withFlows.start(env as never, 'constructor' as never, {} as never)).rejects.toThrow(/flow is not registered/);
 		await expect(withFlows.start(env as never, 'toString' as never, {} as never)).rejects.toThrow(/flow is not registered/);
 	});


### PR DESCRIPTION
flowsやschedulesの照合がプロトタイプ鎖まで辿るため, constructorのような名前が登録済みとして通る。
